### PR TITLE
Zenoh 1.3.0への対応と地図の切り替え機能追加

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,2 +1,8 @@
 method_mapping:
+  # <rmf method name>: <kachaka method name>
   dock: return_home
+  localize: switch_map
+mapname_mapping:
+  # <rmf map name>: <kachaka map name>
+  27F: L27
+  29F: L29

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,7 +2,7 @@ method_mapping:
   # <rmf method name>: <kachaka method name>
   dock: return_home
   localize: switch_map
-mapname_mapping:
+map_name_mapping:
   # <rmf map name>: <kachaka map name>
   27F: L27
   29F: L29

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -36,7 +36,10 @@ cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
 export KACHAKA_IP=$KACHAKA_IP
-export KACHAKA_ACCESS_POINT=\$KACHAKA_IP:26400
+# When running on the Kachaka robot internally, KACHAKA_ACCESS_POINT is optional
+if [ -n "$KACHAKA_IP" ]; then
+  export KACHAKA_ACCESS_POINT=\$KACHAKA_IP:26400
+fi
 export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export PATH=/home/kachaka/.local/bin:\$PATH

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -51,4 +51,5 @@ EOF
 # Securely copy the server setup script and any additional scripts to the server.
 scp -P $SSH_PORT kachaka_startup.sh kachaka@$KACHAKA_IP:~/
 scp -P $SSH_PORT scripts/*.py kachaka@$KACHAKA_IP:~/sbgisen
+scp -r -P $SSH_PORT config/ kachaka@$KACHAKA_IP:~/sbgisen
 echo "Setup script and additional scripts have been copied to the server."

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -56,6 +56,7 @@ class KachakaApiClientByZenoh:
             config = yaml.safe_load(f)
         self.method_mapping = config.get('method_mapping', {})
         self.map_name_mapping = config.get('map_name_mapping', {})
+        self.reverse_map_name_mapping = {v: k for k, v in self.map_name_mapping.items()}
         self.zenoh_config = config.get('zenoh_config', None)
         self.kachaka_client = kachaka_api.KachakaApiClient(kachaka_access_point)
         self.robot_name = robot_name
@@ -123,7 +124,8 @@ class KachakaApiClientByZenoh:
         """Publish the current map name to Zenoh."""
         map_list = await self.run_method('get_map_list')
         search_id = await self.run_method('get_current_map_id')
-        map_name = next((item['name'] for item in map_list if item['id'] == search_id), 'L1')
+        kachaka_map_name = next((item['name'] for item in map_list if item['id'] == search_id), 'L1')
+        map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
         self.map_name_pub.put(json.dumps(map_name).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
 
     async def switch_map(self, args: dict) -> None:

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -18,21 +18,21 @@
 import asyncio
 import json
 import os
-import time
 from pathlib import Path
-from typing import Any
-from typing import Union
+import time
+from typing import Any, Union
 
+from google._upb._message import RepeatedCompositeContainer
+from google.protobuf.json_format import MessageToDict
 import kachaka_api
 import yaml
 import zenoh
-from google._upb._message import RepeatedCompositeContainer
-from google.protobuf.json_format import MessageToDict
 from zenoh import Sample
 
 
 class KachakaApiClientByZenoh:
     """A client for the Kachaka API that publishes data to Zenoh.
+
     This class connects to a Kachaka API server and a Zenoh router,
     and provides methods to publish the robot's pose, current map name,
     and command state to Zenoh topics. It also subscribes to a command
@@ -40,16 +40,17 @@ class KachakaApiClientByZenoh:
     """
 
     def __init__(self, zenoh_router: str, kachaka_access_point: str, robot_name: str, config_file: str) -> None:
-        """Constructor method.
+        """Construct method.
+
         Args:
             zenoh_router (str): The address of the Zenoh router to connect to,
                 in the format "ip:port".
             kachaka_access_point (str): The URL of the Kachaka API server.
             robot_name (str): The name of the robot, used in Zenoh topic names.
+            config_file (str): The name of the configuration file to load.
         """
-
         file_path = Path(__file__).resolve().parent.parent
-        with open(file_path / "config" / config_file, 'r') as f:
+        with open(file_path / 'config' / config_file, 'r') as f:
             config = yaml.safe_load(f)
         self.method_mapping = config.get('method_mapping', {})
         self.map_name_mapping = config.get('map_name_mapping', {})
@@ -60,17 +61,19 @@ class KachakaApiClientByZenoh:
 
         # Initialize Zenoh session and publishers in constructor
         self.session = zenoh.open(self._get_zenoh_config(zenoh_router))
-        self.pose_pub = self.session.declare_publisher(f"robots/{self.robot_name}/pose")
-        self.battery_pub = self.session.declare_publisher(f"robots/{self.robot_name}/battery")
-        self.map_name_pub = self.session.declare_publisher(f"robots/{self.robot_name}/map_name")
+        self.pose_pub = self.session.declare_publisher(f'robots/{self.robot_name}/pose')
+        self.battery_pub = self.session.declare_publisher(f'robots/{self.robot_name}/battery')
+        self.map_name_pub = self.session.declare_publisher(f'robots/{self.robot_name}/map_name')
         self.command_is_completed_pub = self.session.declare_publisher(
-            f"robots/{self.robot_name}/command_is_completed")
+            f'robots/{self.robot_name}/command_is_completed')
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
+
         Args:
             zenoh_router (str): The address of the Zenoh router to connect to,
                 in the format "ip:port".
+
         Returns:
             zenoh.Config: A Zenoh configuration object.
         """
@@ -80,10 +83,12 @@ class KachakaApiClientByZenoh:
 
     async def run_method(self, method_name: str, args: dict = {}) -> Any:  # noqa: ANN401
         """Run a KachakaApiClient method with the provided arguments.
+
         Args:
             method_name (str): The name of the method to run.
             args (dict, optional): The arguments to pass to the method.
                 Defaults to None.
+
         Returns:
             Any: The result of the method call, converted to a dictionary
                 or list if it is a protobuf message.
@@ -95,66 +100,67 @@ class KachakaApiClientByZenoh:
 
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh."""
-        pose_raw = await self.run_method("get_robot_pose")
+        pose_raw = await self.run_method('get_robot_pose')
         try:
-            pose = [pose_raw["x"], pose_raw["y"], pose_raw["theta"]]
+            pose = [pose_raw['x'], pose_raw['y'], pose_raw['theta']]
         except KeyError:
             # Handle unexpected format or missing data appropriately
-            print(f"{pose_raw} is unexpected response format")
+            print(f'{pose_raw} is unexpected response format')
             return
         self.pose_pub.put(json.dumps(pose).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
 
     async def publish_battery(self) -> None:
         """Publish the current robot battery to Zenoh."""
-        res = await self.run_method("get_battery_info")
+        res = await self.run_method('get_battery_info')
         if isinstance(res, (list, tuple)) and len(res) > 0:
             battery = res[0] / 100.0
         self.battery_pub.put(json.dumps(battery).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
 
     async def publish_map_name(self) -> None:
         """Publish the current map name to Zenoh."""
-        map_list = await self.run_method("get_map_list")
-        search_id = await self.run_method("get_current_map_id")
-        map_name = next((item["name"] for item in map_list if item["id"] == search_id), "L1")
+        map_list = await self.run_method('get_map_list')
+        search_id = await self.run_method('get_current_map_id')
+        map_name = next((item['name'] for item in map_list if item['id'] == search_id), 'L1')
         self.map_name_pub.put(json.dumps(map_name).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
 
     async def switch_map(self, args: dict) -> None:
         """Switch the robot to the specified map.
+
         Args:
             args (dict): The arguments for the switch_map method.
         """
         map_name = self.map_name_mapping.get(args.get('map_name'), args.get('map_name'))
-        map_list = await self.run_method("get_map_list")
-        map_id = next((item["id"] for item in map_list if item["name"] == map_name), None)
+        map_list = await self.run_method('get_map_list')
+        map_id = next((item['id'] for item in map_list if item['name'] == map_name), None)
         if map_id is not None:
-            payload = {"map_id": map_id, "pose": args.get("pose", {"x": 0.0, "y": 0.0, "theta": 0.0})}
-            await self.run_method("switch_map", payload)
+            payload = {'map_id': map_id, 'pose': args.get('pose', {'x': 0.0, 'y': 0.0, 'theta': 0.0})}
+            await self.run_method('switch_map', payload)
         else:
-            print(f"Map {map_name} not found")
+            print(f'Map {map_name} not found')
 
     async def publish_result(self) -> None:
         """Publish the last command is_completed to Zenoh."""
-        res = await self.run_method("get_command_state")
-        result = {"id": self.task_id, "is_completed": False}
+        res = await self.run_method('get_command_state')
+        result = {'id': self.task_id, 'is_completed': False}
         if isinstance(res, (list, tuple)) and len(res) > 0 and isinstance(res[0], int):
-            result["is_completed"] = True if res[0] == 1 else False
+            result['is_completed'] = True if res[0] == 1 else False
         else:
             # Handle unexpected format or missing data appropriately
-            raise ValueError(f"{res} is unexpected response format")
+            raise ValueError(f'{res} is unexpected response format')
         self.command_is_completed_pub.put(json.dumps(result).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
 
-    def _to_dict(self,
-                 response: Union[dict, list, RepeatedCompositeContainer, object]
-                 ) -> Union[dict, list, RepeatedCompositeContainer]:
+    def _to_dict(
+        self, response: Union[dict, list, RepeatedCompositeContainer,
+                              object]) -> Union[dict, list, RepeatedCompositeContainer]:
         """Convert a response object to a dictionary or list.
+
         Args:
-            response (Union[dict, list, RepeatedCompositeContainer, object]):
-                The response object to convert.
+            response (Union[dict, list, RepeatedCompositeContainer, object]): The response object to convert.
+
         Returns:
-            Union[dict, list, RepeatedCompositeContainer]: The converted
-                response object.
+            Union[dict, list, RepeatedCompositeContainer]: The converted response object.
         """
-        if response.__class__.__module__ == "kachaka_api_pb2":
+        if response.__class__.__module__ == 'kachaka_api_pb2':
             return MessageToDict(response)
         if isinstance(response, (tuple, list, RepeatedCompositeContainer)):
             return [self._to_dict(item) for item in response]
@@ -162,11 +168,14 @@ class KachakaApiClientByZenoh:
 
     def _command_callback(self, sample: Sample) -> None:
         """Handle received command samples.
+
         This method is called whenever a command is received on the subscribed
         Zenoh topic. It parses the command JSON, validates it, and runs the
         specified method with the provided arguments.
+
         Args:
             sample (Sample): The received Zenoh sample containing the command.
+
         Raises:
             ValueError: If the command structure is invalid.
             AttributeError: If the specified method does not exist on the
@@ -176,31 +185,32 @@ class KachakaApiClientByZenoh:
         try:
             command = json.loads(sample.payload.decode('utf-8'))
             if not all(k in command for k in ('method', 'args')):
-                raise ValueError("Invalid command structure")
+                raise ValueError('Invalid command structure')
             method_name = command['method']
             method_name = self.method_mapping.get(method_name, method_name)
             self.task_id = command.get('id', None)
             if not hasattr(self.kachaka_client, method_name):
-                raise AttributeError(f"Invalid method: {method_name}")
-            print(f"Received command: {command}")
-            if method_name == "switch_map":
+                raise AttributeError(f'Invalid method: {method_name}')
+            print(f'Received command: {command}')
+            if method_name == 'switch_map':
                 asyncio.run(self.switch_map(command['args']))
             else:
                 asyncio.run(self.run_method(method_name, command['args']))
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
-            print(f"Invalid command: {str(e)}")
+            print(f'Invalid command: {str(e)}')
 
     def subscribe_command(self) -> zenoh.Subscriber:
         """Subscribe to the command topic.
+
         Returns:
             zenoh.Subscriber: The Zenoh subscriber object.
         """
-        return self.session.declare_subscriber(
-            f"robots/{self.robot_name}/command", self._command_callback)
+        return self.session.declare_subscriber(f'robots/{self.robot_name}/command', self._command_callback)
 
 
 def main() -> None:
-    """The main function to run the KachakaApiClientByZenoh.
+    """Run the main function to run the KachakaApiClientByZenoh.
+
     This function parses command-line arguments, creates an instance of
     KachakaApiClientByZenoh, subscribes to the command topic, and publishes
     the robot's pose, current map name, and command state to Zenoh in a loop.
@@ -210,12 +220,12 @@ def main() -> None:
     robot_name = os.getenv('ROBOT_NAME', 'kachaka')
     config_file = os.getenv('CONFIG_FILE', 'config.yaml')
     if not zenoh_router_ap or not kachaka_access_point:
-        raise ValueError("ZENOH_ROUTER_ACCESS_POINT and KACHAKA_ACCESS_POINT must be set as environment variables.")
+        raise ValueError('ZENOH_ROUTER_ACCESS_POINT and KACHAKA_ACCESS_POINT must be set as environment variables.')
 
     node = KachakaApiClientByZenoh(zenoh_router_ap, kachaka_access_point, robot_name, config_file)
     try:
         sub = node.subscribe_command()
-        print(f"Subscribed to {sub}")
+        print(f'Subscribed to {sub}')
         while True:
             asyncio.run(node.publish_pose())
             asyncio.run(node.publish_battery())
@@ -223,9 +233,9 @@ def main() -> None:
             asyncio.run(node.publish_result())
             time.sleep(1)
     except KeyboardInterrupt:
-        node.session.delete(f"robots/{robot_name}/**")
+        node.session.delete(f'robots/{robot_name}/**')
         node.session.close()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -17,10 +17,11 @@
 
 import asyncio
 import json
+import logging
 import os
 from pathlib import Path
 import time
-from typing import Any, Union
+from typing import Any, Dict, List, Optional, Union
 
 from google._upb._message import RepeatedCompositeContainer
 from google.protobuf.json_format import MessageToDict
@@ -41,7 +42,27 @@ class KachakaApiClientByZenoh:
     topic to receive and execute commands.
     """
 
-    def __init__(self, zenoh_router: str, kachaka_access_point: str, robot_name: str, config_file: str) -> None:
+    session: zenoh.Session
+    pose_pub: zenoh.Publisher
+    battery_pub: zenoh.Publisher
+    map_name_pub: zenoh.Publisher
+    command_is_completed_pub: zenoh.Publisher
+    kachaka_client: Any  # kachaka_api.KachakaApiClient
+    method_mapping: Dict[str, str]
+    map_name_mapping: Dict[str, str]
+    reverse_map_name_mapping: Dict[str, str]
+    zenoh_config: Optional[str]
+    robot_name: str
+    task_id: Optional[str]
+    logger: logging.Logger
+
+    def __init__(
+        self,
+        zenoh_router: str,
+        kachaka_access_point: str,
+        robot_name: str,
+        config_file: str,
+    ) -> None:
         """Construct method.
 
         Args:
@@ -61,6 +82,12 @@ class KachakaApiClientByZenoh:
         self.kachaka_client = kachaka_api.KachakaApiClient(kachaka_access_point)
         self.robot_name = robot_name
         self.task_id = None
+        logging.basicConfig(
+            level=logging.INFO,
+            format='%(asctime)s - %(levelname)s - %(message)s',
+            filename='kachaka_api.log',
+        )
+        self.logger = logging.getLogger(__name__)
 
         # Initialize Zenoh session and publishers in constructor
         self.session = zenoh.open(self._get_zenoh_config(zenoh_router))
@@ -69,6 +96,7 @@ class KachakaApiClientByZenoh:
         self.map_name_pub = self.session.declare_publisher(f'robots/{self.robot_name}/map_name')
         self.command_is_completed_pub = self.session.declare_publisher(
             f'robots/{self.robot_name}/command_is_completed')
+        self.logger.info(f'Initialized KachakaApiClientByZenoh for robot {robot_name}')
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -84,7 +112,7 @@ class KachakaApiClientByZenoh:
         conf.insert_json5('connect/endpoints', json.dumps([f'tcp/{zenoh_router}']))
         return conf
 
-    async def run_method(self, method_name: str, args: dict = {}) -> Any:  # noqa: ANN401
+    async def run_method(self, method_name: str, args: Dict[str, Any] = {}) -> Any:  # noqa: ANN401
         """Run a KachakaApiClient method with the provided arguments.
 
         Args:
@@ -95,64 +123,243 @@ class KachakaApiClientByZenoh:
         Returns:
             Any: The result of the method call, converted to a dictionary
                 or list if it is a protobuf message.
+
+        Raises:
+            ConnectionError: If gRPC connection check fails after max retries
+            RpcError: If any other gRPC error occurs
         """
-        self.grpc_connection_check()
+        if not self.grpc_connection_check():
+            error_msg = f'Failed to connect to Kachaka API server after max retries for method {method_name}'
+            self.logger.error(error_msg)
+            raise ConnectionError(error_msg)
+
         args = args or {}
-        method = getattr(self.kachaka_client, method_name)
-        response = self._to_dict(method(**args))
-        return response
-
-    async def publish_pose(self) -> None:
-        """Publish the current robot pose to Zenoh."""
-        pose_raw = await self.run_method('get_robot_pose')
         try:
-            pose = [pose_raw['x'], pose_raw['y'], pose_raw['theta']]
-        except KeyError:
-            # Handle unexpected format or missing data appropriately
-            print(f'{pose_raw} is unexpected response format')
-            return
-        self.pose_pub.put(json.dumps(pose).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
+            method = getattr(self.kachaka_client, method_name)
+            response = self._to_dict(method(**args))
+            return response
+        except RpcError as e:
+            self.logger.error(f'RPC error in {method_name}: {e.details()}')
+            raise
 
-    async def publish_battery(self) -> None:
-        """Publish the current robot battery to Zenoh."""
-        res = await self.run_method('get_battery_info')
-        if isinstance(res, (list, tuple)) and len(res) > 0:
-            battery = res[0] / 100.0
-        self.battery_pub.put(json.dumps(battery).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
-
-    async def publish_map_name(self) -> None:
-        """Publish the current map name to Zenoh."""
-        map_list = await self.run_method('get_map_list')
-        search_id = await self.run_method('get_current_map_id')
-        kachaka_map_name = next((item['name'] for item in map_list if item['id'] == search_id), 'L1')
-        map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
-        self.map_name_pub.put(json.dumps(map_name).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
-
-    async def switch_map(self, args: dict) -> None:
-        """Switch the robot to the specified map.
+    def _log_error(self, error_type: str, method_name: str, error: Exception) -> None:
+        """Log an error with consistent formatting.
 
         Args:
-            args (dict): The arguments for the switch_map method.
+            error_type (str): Type of error (Connection, RPC, etc.)
+            method_name (str): Name of the method where the error occurred
+            error (Exception): The exception object
         """
-        map_name = self.map_name_mapping.get(args.get('map_name'), args.get('map_name'))
-        map_list = await self.run_method('get_map_list')
-        map_id = next((item['id'] for item in map_list if item['name'] == map_name), None)
-        if map_id is not None:
-            payload = {'map_id': map_id, 'pose': args.get('pose', {'x': 0.0, 'y': 0.0, 'theta': 0.0})}
-            await self.run_method('switch_map', payload)
-        else:
-            print(f'Map {map_name} not found')
+        error_msg = f'{error_type} error during {method_name}: {str(error)}'
+        if isinstance(error, RpcError):
+            error_msg = f'{error_type} error during {method_name}: {error.details()}'
+
+        self.logger.error(error_msg)
+        print(error_msg)
+
+    def _publish_to_zenoh(self, publisher: zenoh.Publisher, data: Union[Dict, List, str, int, float, bool]) -> None:
+        """Publish data to a Zenoh topic with consistent encoding.
+
+        Args:
+            publisher: The Zenoh publisher to use
+            data: The data to publish (will be JSON-encoded)
+        """
+        publisher.put(json.dumps(data).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
+
+    async def publish_pose(self) -> None:
+        """Publish the current robot pose to Zenoh.
+
+        Gets the robot's current pose from Kachaka API and publishes it to Zenoh.
+        The pose is formatted as a list [x, y, theta] where:
+        - x, y: position coordinates in meters
+        - theta: orientation in radians
+
+        Handles connection errors and unexpected response formats.
+
+        Raises:
+            Does not raise exceptions as they are caught and logged internally.
+        """
+        method_name = 'publish_pose'
+        try:
+            pose_raw = await self.run_method('get_robot_pose')
+            try:
+                pose = [pose_raw['x'], pose_raw['y'], pose_raw['theta']]
+            except KeyError:
+                # Handle unexpected format or missing data appropriately
+                self.logger.error(f'{pose_raw} is unexpected response format')
+                print(f'{pose_raw} is unexpected response format')
+                return
+
+            self._publish_to_zenoh(self.pose_pub, pose)
+        except ConnectionError as e:
+            self._log_error('Connection', method_name, e)
+        except RpcError as e:
+            self._log_error('RPC', method_name, e)
+        except Exception as e:
+            self._log_error('Unexpected', method_name, e)
+
+    async def publish_battery(self) -> None:
+        """Publish the current robot battery to Zenoh.
+
+        Gets battery information from Kachaka API and publishes it to Zenoh.
+        Battery level is normalized to a 0.0-1.0 range from the original percentage.
+
+        Handles connection errors and unexpected response formats.
+
+        Raises:
+            Does not raise exceptions as they are caught and logged internally.
+        """
+        method_name = 'publish_battery'
+        try:
+            res = await self.run_method('get_battery_info')
+            if isinstance(res, (list, tuple)) and len(res) > 0:
+                battery = res[0] / 100.0
+            else:
+                self.logger.error(f'Unexpected battery info format: {res}')
+                print(f'Unexpected battery info format: {res}')
+                return
+
+            self._publish_to_zenoh(self.battery_pub, battery)
+        except ConnectionError as e:
+            self._log_error('Connection', method_name, e)
+        except RpcError as e:
+            self._log_error('RPC', method_name, e)
+        except Exception as e:
+            self._log_error('Unexpected', method_name, e)
+
+    async def publish_map_name(self) -> None:
+        """Publish the current map name to Zenoh.
+
+        Gets the current map ID from Kachaka, looks up the map name
+        from the map list, applies any name mapping defined in the configuration,
+        and publishes the map name to Zenoh.
+
+        Uses the reverse_map_name_mapping to convert Kachaka's internal map names
+        (e.g., 'L27') to more descriptive names (e.g., '27F').
+
+        Handles connection errors and unexpected response formats.
+
+        Raises:
+            Does not raise exceptions as they are caught and logged internally.
+        """
+        method_name = 'publish_map_name'
+        try:
+            map_list = await self.run_method('get_map_list')
+            search_id = await self.run_method('get_current_map_id')
+
+            kachaka_map_name = next((item['name'] for item in map_list if item['id'] == search_id), 'L1')
+            map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
+
+            self._publish_to_zenoh(self.map_name_pub, map_name)
+        except ConnectionError as e:
+            self._log_error('Connection', method_name, e)
+        except RpcError as e:
+            self._log_error('RPC', method_name, e)
+        except Exception as e:
+            self._log_error('Unexpected', method_name, e)
+
+    async def switch_map(self, args: Dict[str, Any]) -> None:
+        """Switch the robot to the specified map.
+
+        Handles the switch_map command from Zenoh, looking up the map by name
+        in the Kachaka API, and switching to it if it exists and is different
+        from the current map.
+
+        Applies any required name mappings defined in the configuration,
+        allowing for use of custom map names.
+
+        Args:
+            args (dict): The arguments for the switch_map method, including:
+                - map_name (str): The name of the map to switch to
+                - pose (dict, optional): The initial pose on the new map
+                  with x, y, theta keys. Defaults to origin with zero orientation.
+
+        Note:
+            Only switches maps if the requested map is different from the current one,
+            as the switching process can be time-consuming.
+
+        Raises:
+            Does not raise exceptions as they are caught and logged internally.
+        """
+        method_name = 'switch_map'
+        try:
+            map_name = self.map_name_mapping.get(args.get('map_name'), args.get('map_name'))
+            map_list = await self.run_method('get_map_list')
+            map_id = next((item['id'] for item in map_list if item['name'] == map_name), None)
+
+            if map_id is None:
+                self.logger.error(f'Map {map_name} not found')
+                print(f'Map {map_name} not found')
+                return
+
+            current_map_id = await self.run_method('get_current_map_id')
+            payload = {
+                'map_id': map_id,
+                'pose': args.get('pose', {
+                    'x': 0.0,
+                    'y': 0.0,
+                    'theta': 0.0
+                }),
+            }
+
+            # switch map only if the map is different from the current map id
+            # because switch_map method takes long time to complete
+            if map_id != current_map_id:
+                await self.run_method('switch_map', payload)
+
+            self.logger.info(f'Switched to map {map_name}')
+        except ConnectionError as e:
+            self._log_error('Connection', method_name, e)
+        except RpcError as e:
+            self._log_error('RPC', method_name, e)
+        except Exception as e:
+            self._log_error('Unexpected', method_name, e)
 
     async def publish_result(self) -> None:
-        """Publish the last command is_completed to Zenoh."""
-        res = await self.run_method('get_command_state')
-        result = {'id': self.task_id, 'is_completed': False}
-        if isinstance(res, (list, tuple)) and len(res) > 0 and isinstance(res[0], int):
-            result['is_completed'] = True if res[0] == 1 else False
-        else:
-            # Handle unexpected format or missing data appropriately
-            raise ValueError(f'{res} is unexpected response format')
-        self.command_is_completed_pub.put(json.dumps(result).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
+        """Publish the last command completion status to Zenoh.
+
+        Checks the status of the most recently executed command and publishes
+        its completion status (true/false) to Zenoh along with the task ID.
+
+        Only publishes if there is an active task (task_id is set).
+        The task_id is set when a command is received via the Zenoh command topic.
+
+        The published result has the format:
+        {
+            "id": "<task_id>",
+            "is_completed": true/false
+        }
+
+        Handles connection errors and unexpected response formats.
+
+        Raises:
+            Does not raise exceptions as they are caught and logged internally.
+        """
+        method_name = 'publish_result'
+        try:
+            if not self.task_id:
+                # No active task to check
+                return
+
+            res = await self.run_method('get_command_state')
+            result = {'id': self.task_id, 'is_completed': False}
+
+            if isinstance(res, (list, tuple)) and len(res) > 0 and isinstance(res[0], int):
+                result['is_completed'] = True if res[0] == 1 else False
+            else:
+                # Handle unexpected format or missing data appropriately
+                self.logger.error(f'Unexpected command state format: {res}')
+                print(f'Unexpected command state format: {res}')
+                return
+
+            self.logger.info(f'Published command result: {result}')
+            self._publish_to_zenoh(self.command_is_completed_pub, result)
+        except ConnectionError as e:
+            self._log_error('Connection', method_name, e)
+        except RpcError as e:
+            self._log_error('RPC', method_name, e)
+        except Exception as e:
+            self._log_error('Unexpected', method_name, e)
 
     def _to_dict(
         self, response: Union[dict, list, RepeatedCompositeContainer,
@@ -191,17 +398,31 @@ class KachakaApiClientByZenoh:
             command = json.loads(sample.payload.to_string())
             if not all(k in command for k in ('method', 'args')):
                 raise ValueError('Invalid command structure')
+
             method_name = command['method']
             method_name = self.method_mapping.get(method_name, method_name)
             self.task_id = command.get('id', None)
+
             if not hasattr(self.kachaka_client, method_name):
                 raise AttributeError(f'Invalid method: {method_name}')
+
+            self.logger.info(f'Received command: {command}')
             print(f'Received command: {command}')
-            if method_name == 'switch_map':
-                asyncio.run(self.switch_map(command['args']))
-            else:
-                asyncio.run(self.run_method(method_name, command['args']))
+
+            try:
+                if method_name == 'switch_map':
+                    asyncio.run(self.switch_map(command['args']))
+                else:
+                    asyncio.run(self.run_method(method_name, command['args']))
+            except ConnectionError as e:
+                self._log_error('Connection', f'executing command {method_name}', e)
+            except RpcError as e:
+                self._log_error('RPC', f'executing command {method_name}', e)
+            except Exception as e:
+                self._log_error('Unexpected', f'executing command {method_name}', e)
+
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
+            self.logger.error(f'Invalid command: {str(e)}')
             print(f'Invalid command: {str(e)}')
 
     def subscribe_command(self) -> zenoh.Subscriber:
@@ -213,23 +434,94 @@ class KachakaApiClientByZenoh:
         return self.session.declare_subscriber(f'robots/{self.robot_name}/command', self._command_callback)
 
     def grpc_connection_check(self) -> bool:
-        """Check if the gRPC connection is alive.
+        """Check if the gRPC connection to Kachaka API server is alive.
+
+        Attempts to make a simple API call (get_robot_pose) to check if the
+        connection is working. If the connection fails with UNAVAILABLE status,
+        it will retry up to max_retries times with a sleep interval between retries.
+
+        For other RPC errors, the error is re-raised as they indicate issues
+        other than connection problems.
+
+        Args:
+            None
 
         Returns:
-            Bool: True if the connection is alive, False otherwise.
+            bool: True if the connection is alive, False if it could not be
+                 established after max_retries
+
+        Raises:
+            RpcError: If an RPC error occurs that is not related to connection
+                      availability (not StatusCode.UNAVAILABLE)
         """
         max_retries = 20
         sleep_time = 5
+        retry_count = 0
+        last_error = None
+
         for i in range(max_retries):
             try:
                 self.kachaka_client.get_robot_pose()
+                if retry_count > 0:
+                    self.logger.info(f'gRPC connection restored after {retry_count} retries')
+                    print(f'gRPC connection restored after {retry_count} retries')
                 return True
             except RpcError as e:
+                retry_count += 1
+                last_error = e
                 if e.code() == StatusCode.UNAVAILABLE:
-                    print(f'gRPC connection error: {e.details()}')
+                    self.logger.error(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
+                    print(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
                     time.sleep(sleep_time)
                 else:
+                    self.logger.error(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
+                    print(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
                     raise e
+
+        error_details = last_error.details() if last_error else 'Unknown error'
+        self.logger.error(
+            f'Failed to connect to gRPC server after {max_retries} attempts. Last error: {error_details}')
+        print(f'Failed to connect to gRPC server after {max_retries} attempts')
+        return False
+
+
+def _handle_main_loop_error(
+    node: KachakaApiClientByZenoh,
+    error: Exception,
+    consecutive_errors: int,
+    max_consecutive_errors: int,
+) -> int:
+    """Handle errors in the main loop.
+
+    Args:
+        node: The KachakaApiClientByZenoh node instance
+        error: The exception that was raised
+        consecutive_errors: Current count of consecutive errors
+        max_consecutive_errors: Maximum allowed consecutive errors
+
+    Returns:
+        int: Updated consecutive_errors count
+
+    Raises:
+        Exception: If too many consecutive errors occur
+    """
+    consecutive_errors += 1
+    if isinstance(error, RpcError) and error.code() == StatusCode.UNAVAILABLE:
+        node.logger.error(f'Connection RPC error in main loop: {error.details()}')
+    elif isinstance(error, ConnectionError):
+        node.logger.error(f'Connection error in main loop: {str(error)}')
+    elif isinstance(error, RpcError):
+        node.logger.error(f'Unexpected RPC error in main loop: {error.details()}')
+        raise error
+    else:
+        node.logger.error(f'Unexpected error in main loop: {str(error)}')
+
+    if consecutive_errors >= max_consecutive_errors:
+        node.logger.error(f'Too many consecutive errors ({consecutive_errors}), exiting')
+        print(f'Too many consecutive errors ({consecutive_errors}), exiting')
+        raise error
+
+    return consecutive_errors
 
 
 def main() -> None:
@@ -246,19 +538,43 @@ def main() -> None:
     if not zenoh_router_ap or not kachaka_access_point:
         raise ValueError('ZENOH_ROUTER_ACCESS_POINT and KACHAKA_ACCESS_POINT must be set as environment variables.')
 
-    node = KachakaApiClientByZenoh(zenoh_router_ap, kachaka_access_point, robot_name, config_file)
     try:
-        sub = node.subscribe_command()
-        print(f'Subscribed to {sub}')
-        while True:
-            asyncio.run(node.publish_pose())
-            asyncio.run(node.publish_battery())
-            asyncio.run(node.publish_map_name())
-            asyncio.run(node.publish_result())
-            time.sleep(1)
-    except KeyboardInterrupt:
-        node.session.delete(f'robots/{robot_name}/**')
-        node.session.close()
+        node = KachakaApiClientByZenoh(zenoh_router_ap, kachaka_access_point, robot_name, config_file)
+
+        try:
+            sub = node.subscribe_command()
+            print(f'Subscribed to {sub}')
+            node.logger.info(f'Subscribed to {sub}')
+
+            consecutive_errors = 0
+            max_consecutive_errors = 10
+            sleep_time = 1
+
+            while True:
+                try:
+                    asyncio.run(node.publish_pose())
+                    asyncio.run(node.publish_battery())
+                    asyncio.run(node.publish_map_name())
+                    asyncio.run(node.publish_result())
+                    consecutive_errors = 0  # Reset on success
+                except (ConnectionError, RpcError, Exception) as e:
+                    consecutive_errors = _handle_main_loop_error(node, e, consecutive_errors, max_consecutive_errors)
+
+                time.sleep(sleep_time)
+
+        except KeyboardInterrupt:
+            print('Interrupted by user, cleaning up...')
+        finally:
+            # Clean up zenoh session
+            node.session.delete(f'robots/{robot_name}/**')
+            node.session.close()
+            node.logger.info('Closed Zenoh session')
+            node.logger.info('Exiting KachakaApiClientByZenoh')
+
+    except Exception as e:
+        print(f'Failed to initialize or run KachakaApiClientByZenoh: {str(e)}')
+        logging.error(f'Failed to initialize or run KachakaApiClientByZenoh: {str(e)}')
+        raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- 変更の目的 または 概要-->
## Summary

変更点が多岐に渡り、大きなPRになってしまいました。※レビューがしにくい場合はPRを分割させていただきます。
変更箇所は、下記となります。
- 地図の変更に対応
- ZenohのVersion 1.3.0でも動作するようにZenohのConfigや引数を修正
- Debug用にLoggerの追加及びError処理を追加
- Kachaka体内で実行する場合はKachakaのIP指定をしなくともKachakaApiClinetが起動するように変更


<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #11 




## Detail
コミットごとの変更点を書きます。

### c435ac2 - Add switch_map method to connect_openrmf_by_zenoh.py
- `switch_map`メソッドを追加し、異なるマップ間の切り替え機能を実装
- マップ名を指定してロボットのマップを切り替えることが可能に
- 現在のマップと同じ場合は不要な切り替え処理をスキップする最適化を実装
- マップ切り替え時に初期位置（ポーズ）を指定する機能を追加

### 1fc81da - feat: add zenoh configuration support to KachakaApiClientByZenoh
- Zenoh設定ファイルからの読み込みをサポート
- `_get_zenoh_config`メソッドを追加して設定ファイルの読み込み処理を実装
- 設定ファイルが指定されていない場合のデフォルト設定処理も実装
- Zenohルーターへの接続設定をより柔軟に行えるように改善

### 5efb0f1 - Improve code formatting and consistency in connect_openrmf_by_zenoh.py
- コードの書式と一貫性を全体的に改善
- インデントやスペースの使用を統一
- 変数名や関数名の命名規則を統一
- コメントの書式を整理して可読性を向上

### 39a49b5 - Add gRPC connection check and enhance config handling
- Kachaka APIへのgRPC接続チェック機能を追加
- 接続エラー時の適切なエラーハンドリングを実装
- 設定ファイルの読み込み処理を強化
- 設定パラメータの検証機能を追加

### d569823 - Add reverse mapping for map names in KachakaApiClientByZenoh
- マップ名の逆マッピング機能を追加（KachakaマップからRMFマップへの変換）
- `reverse_map_name_mapping`を実装し、双方向の名前変換をサポート
- `config.yaml`にマップ名のマッピング設定を追加（RMFマップ名とKachakaマップ名の変換用）
- マップ名の変換処理を関連メソッドに適用

### 24708bc - feat: add logging and error handling to KachakaApiClientByZenoh
- 一貫したエラーログ記録のための`_log_error`メソッドを追加
- 異なるタイプのエラー（接続エラー、RPCエラー、予期しないエラー）に対する包括的なエラーハンドリングを実装
- ログレベルの適切な設定とフォーマット定義
- エラーメッセージの詳細化と統一化

### 1a7a9df - feat: make KACHAKA_ACCESS_POINT optional when running internally
- Kachakaロボット内部で実行する場合に`KACHAKA_ACCESS_POINT`を省略可能に変更
- `kachaka_server_setup.sh`スクリプトを更新し、条件付きで環境変数を設定するように変更
- 内部実行時のデフォルト設定を追加
- 設定ディレクトリをロボットにコピーする処理を追加

### db093eb - refactor: improve KachakaApiClientByZenoh code structure
- `KachakaApiClientByZenoh`クラスの全体的な構造を改善
- メソッドのグループ化と整理
- 共通処理の抽出と再利用性の向上
- コード全体のドキュメント文字列（docstring）を充実させ、各メソッドの目的と使用方法を明確化
- 型ヒント（type hints）を追加してコードの安全性と可読性を向上



<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

Open-RMFでのELVにおけるELV連携は動作確認しています。
- マップ切り替え機能の動作確認
- 内部実行時の`KACHAKA_ACCESS_POINT`省略オプションの動作確認
- エラーハンドリングとログ記録の機能確認
- Zenoh設定ファイルからの読み込み機能の確認
<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
