### PR TITLE
地図の切り替え機能追加

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,2 +1,8 @@
 method_mapping:
+  # <rmf method name>: <kachaka method name>
   dock: return_home
+  localize: switch_map
+mapname_mapping:
+  # <rmf map name>: <kachaka map name>
+  27F: L27
+  29F: L29

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,7 +2,7 @@ method_mapping:
   # <rmf method name>: <kachaka method name>
   dock: return_home
   localize: switch_map
-mapname_mapping:
+map_name_mapping:
   # <rmf map name>: <kachaka map name>
   27F: L27
   29F: L29

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -18,21 +18,21 @@
 import asyncio
 import json
 import os
-import time
 from pathlib import Path
-from typing import Any
-from typing import Union
+import time
+from typing import Any, Union
 
+from google._upb._message import RepeatedCompositeContainer
+from google.protobuf.json_format import MessageToDict
 import kachaka_api
 import yaml
 import zenoh
-from google._upb._message import RepeatedCompositeContainer
-from google.protobuf.json_format import MessageToDict
 from zenoh import Sample
 
 
 class KachakaApiClientByZenoh:
     """A client for the Kachaka API that publishes data to Zenoh.
+
     This class connects to a Kachaka API server and a Zenoh router,
     and provides methods to publish the robot's pose, current map name,
     and command state to Zenoh topics. It also subscribes to a command
@@ -40,16 +40,17 @@ class KachakaApiClientByZenoh:
     """
 
     def __init__(self, zenoh_router: str, kachaka_access_point: str, robot_name: str, config_file: str) -> None:
-        """Constructor method.
+        """Construct method.
+
         Args:
             zenoh_router (str): The address of the Zenoh router to connect to,
                 in the format "ip:port".
             kachaka_access_point (str): The URL of the Kachaka API server.
             robot_name (str): The name of the robot, used in Zenoh topic names.
+            config_file (str): The name of the configuration file to load.
         """
-
         file_path = Path(__file__).resolve().parent.parent
-        with open(file_path / "config" / config_file, 'r') as f:
+        with open(file_path / 'config' / config_file, 'r') as f:
             config = yaml.safe_load(f)
         self.method_mapping = config.get('method_mapping', {})
         self.map_name_mapping = config.get('map_name_mapping', {})
@@ -61,17 +62,19 @@ class KachakaApiClientByZenoh:
 
         # Initialize Zenoh session and publishers in constructor
         self.session = zenoh.open(self._get_zenoh_config(zenoh_router))
-        self.pose_pub = self.session.declare_publisher(f"robots/{self.robot_name}/pose")
-        self.battery_pub = self.session.declare_publisher(f"robots/{self.robot_name}/battery")
-        self.map_name_pub = self.session.declare_publisher(f"robots/{self.robot_name}/map_name")
+        self.pose_pub = self.session.declare_publisher(f'robots/{self.robot_name}/pose')
+        self.battery_pub = self.session.declare_publisher(f'robots/{self.robot_name}/battery')
+        self.map_name_pub = self.session.declare_publisher(f'robots/{self.robot_name}/map_name')
         self.command_is_completed_pub = self.session.declare_publisher(
-            f"robots/{self.robot_name}/command_is_completed")
+            f'robots/{self.robot_name}/command_is_completed')
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
+
         Args:
             zenoh_router (str): The address of the Zenoh router to connect to,
                 in the format "ip:port".
+
         Returns:
             zenoh.Config: A Zenoh configuration object.
         """
@@ -81,10 +84,12 @@ class KachakaApiClientByZenoh:
 
     async def run_method(self, method_name: str, args: dict = {}) -> Any:  # noqa: ANN401
         """Run a KachakaApiClient method with the provided arguments.
+
         Args:
             method_name (str): The name of the method to run.
             args (dict, optional): The arguments to pass to the method.
                 Defaults to None.
+
         Returns:
             Any: The result of the method call, converted to a dictionary
                 or list if it is a protobuf message.
@@ -96,18 +101,18 @@ class KachakaApiClientByZenoh:
 
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh."""
-        pose_raw = await self.run_method("get_robot_pose")
+        pose_raw = await self.run_method('get_robot_pose')
         try:
-            pose = [pose_raw["x"], pose_raw["y"], pose_raw["theta"]]
+            pose = [pose_raw['x'], pose_raw['y'], pose_raw['theta']]
         except KeyError:
             # Handle unexpected format or missing data appropriately
-            print(f"{pose_raw} is unexpected response format")
+            print(f'{pose_raw} is unexpected response format')
             return
         self.pose_pub.put(json.dumps(pose).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
 
     async def publish_battery(self) -> None:
         """Publish the current robot battery to Zenoh."""
-        res = await self.run_method("get_battery_info")
+        res = await self.run_method('get_battery_info')
         if isinstance(res, (list, tuple)) and len(res) > 0:
             battery = res[0] / 100.0
         self.battery_pub.put(json.dumps(battery).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
@@ -122,41 +127,42 @@ class KachakaApiClientByZenoh:
 
     async def switch_map(self, args: dict) -> None:
         """Switch the robot to the specified map.
+
         Args:
             args (dict): The arguments for the switch_map method.
         """
         map_name = self.map_name_mapping.get(args.get('map_name'), args.get('map_name'))
-        map_list = await self.run_method("get_map_list")
-        map_id = next((item["id"] for item in map_list if item["name"] == map_name), None)
+        map_list = await self.run_method('get_map_list')
+        map_id = next((item['id'] for item in map_list if item['name'] == map_name), None)
         if map_id is not None:
-            payload = {"map_id": map_id, "pose": args.get("pose", {"x": 0.0, "y": 0.0, "theta": 0.0})}
-            await self.run_method("switch_map", payload)
+            payload = {'map_id': map_id, 'pose': args.get('pose', {'x': 0.0, 'y': 0.0, 'theta': 0.0})}
+            await self.run_method('switch_map', payload)
         else:
-            print(f"Map {map_name} not found")
+            print(f'Map {map_name} not found')
 
     async def publish_result(self) -> None:
         """Publish the last command is_completed to Zenoh."""
-        res = await self.run_method("get_command_state")
-        result = {"id": self.task_id, "is_completed": False}
+        res = await self.run_method('get_command_state')
+        result = {'id': self.task_id, 'is_completed': False}
         if isinstance(res, (list, tuple)) and len(res) > 0 and isinstance(res[0], int):
-            result["is_completed"] = True if res[0] == 1 else False
+            result['is_completed'] = True if res[0] == 1 else False
         else:
             # Handle unexpected format or missing data appropriately
-            raise ValueError(f"{res} is unexpected response format")
+            raise ValueError(f'{res} is unexpected response format')
         self.command_is_completed_pub.put(json.dumps(result).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
 
-    def _to_dict(self,
-                 response: Union[dict, list, RepeatedCompositeContainer, object]
-                 ) -> Union[dict, list, RepeatedCompositeContainer]:
+    def _to_dict(
+        self, response: Union[dict, list, RepeatedCompositeContainer,
+                              object]) -> Union[dict, list, RepeatedCompositeContainer]:
         """Convert a response object to a dictionary or list.
+
         Args:
-            response (Union[dict, list, RepeatedCompositeContainer, object]):
-                The response object to convert.
+            response (Union[dict, list, RepeatedCompositeContainer, object]): The response object to convert.
+
         Returns:
-            Union[dict, list, RepeatedCompositeContainer]: The converted
-                response object.
+            Union[dict, list, RepeatedCompositeContainer]: The converted response object.
         """
-        if response.__class__.__module__ == "kachaka_api_pb2":
+        if response.__class__.__module__ == 'kachaka_api_pb2':
             return MessageToDict(response)
         if isinstance(response, (tuple, list, RepeatedCompositeContainer)):
             return [self._to_dict(item) for item in response]
@@ -164,11 +170,14 @@ class KachakaApiClientByZenoh:
 
     def _command_callback(self, sample: Sample) -> None:
         """Handle received command samples.
+
         This method is called whenever a command is received on the subscribed
         Zenoh topic. It parses the command JSON, validates it, and runs the
         specified method with the provided arguments.
+
         Args:
             sample (Sample): The received Zenoh sample containing the command.
+
         Raises:
             ValueError: If the command structure is invalid.
             AttributeError: If the specified method does not exist on the
@@ -178,31 +187,32 @@ class KachakaApiClientByZenoh:
         try:
             command = json.loads(sample.payload.decode('utf-8'))
             if not all(k in command for k in ('method', 'args')):
-                raise ValueError("Invalid command structure")
+                raise ValueError('Invalid command structure')
             method_name = command['method']
             method_name = self.method_mapping.get(method_name, method_name)
             self.task_id = command.get('id', None)
             if not hasattr(self.kachaka_client, method_name):
-                raise AttributeError(f"Invalid method: {method_name}")
-            print(f"Received command: {command}")
-            if method_name == "switch_map":
+                raise AttributeError(f'Invalid method: {method_name}')
+            print(f'Received command: {command}')
+            if method_name == 'switch_map':
                 asyncio.run(self.switch_map(command['args']))
             else:
                 asyncio.run(self.run_method(method_name, command['args']))
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
-            print(f"Invalid command: {str(e)}")
+            print(f'Invalid command: {str(e)}')
 
     def subscribe_command(self) -> zenoh.Subscriber:
         """Subscribe to the command topic.
+
         Returns:
             zenoh.Subscriber: The Zenoh subscriber object.
         """
-        return self.session.declare_subscriber(
-            f"robots/{self.robot_name}/command", self._command_callback)
+        return self.session.declare_subscriber(f'robots/{self.robot_name}/command', self._command_callback)
 
 
 def main() -> None:
-    """The main function to run the KachakaApiClientByZenoh.
+    """Run the main function to run the KachakaApiClientByZenoh.
+
     This function parses command-line arguments, creates an instance of
     KachakaApiClientByZenoh, subscribes to the command topic, and publishes
     the robot's pose, current map name, and command state to Zenoh in a loop.
@@ -212,12 +222,12 @@ def main() -> None:
     robot_name = os.getenv('ROBOT_NAME', 'kachaka')
     config_file = os.getenv('CONFIG_FILE', 'config.yaml')
     if not zenoh_router_ap or not kachaka_access_point:
-        raise ValueError("ZENOH_ROUTER_ACCESS_POINT and KACHAKA_ACCESS_POINT must be set as environment variables.")
+        raise ValueError('ZENOH_ROUTER_ACCESS_POINT and KACHAKA_ACCESS_POINT must be set as environment variables.')
 
     node = KachakaApiClientByZenoh(zenoh_router_ap, kachaka_access_point, robot_name, config_file)
     try:
         sub = node.subscribe_command()
-        print(f"Subscribed to {sub}")
+        print(f'Subscribed to {sub}')
         while True:
             asyncio.run(node.publish_pose())
             asyncio.run(node.publish_battery())
@@ -225,9 +235,9 @@ def main() -> None:
             asyncio.run(node.publish_result())
             time.sleep(1)
     except KeyboardInterrupt:
-        node.session.delete(f"robots/{robot_name}/**")
+        node.session.delete(f'robots/{robot_name}/**')
         node.session.close()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #11 

<!-- 変更の詳細 -->
## Detail
### c435ac2 - Add switch_map method to connect_openrmf_by_zenoh.py
- `switch_map`メソッドを追加し、異なるマップ間の切り替え機能を実装
- マップ名を指定してロボットのマップを切り替えることが可能に
- 現在のマップと同じ場合は不要な切り替え処理をスキップする最適化を実装
- マップ切り替え時に初期位置（ポーズ）を指定する機能を追加

### 1fc81da - feat: add zenoh configuration support to KachakaApiClientByZenoh
- Zenoh設定ファイルからの読み込みをサポート
- `_get_zenoh_config`メソッドを追加して設定ファイルの読み込み処理を実装
- 設定ファイルが指定されていない場合のデフォルト設定処理も実装
- Zenohルーターへの接続設定をより柔軟に行えるように改善

### 33ed93480c62c3e7d69ff3186c795c299423df72 - Add reverse mapping for map names in KachakaApiClientByZenoh
- マップ名の逆マッピング機能を追加（KachakaマップからRMFマップへの変換）
- `reverse_map_name_mapping`を実装し、双方向の名前変換をサポート
- `config.yaml`にマップ名のマッピング設定を追加（RMFマップ名とKachakaマップ名の変換用）
- マップ名の変換処理を関連メソッドに適用

### 0fe4e21f48aac5470214c99bc7fc695e76ed5939 - Improve code formatting and consistency in connect_openrmf_by_zenoh.py
- コードの書式と一貫性を全体的に改善
- インデントやスペースの使用を統一
- 変数名や関数名の命名規則を統一
- コメントの書式を整理して可読性を向上


<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
