### PR TITLE
Add option for wait_for_completion=False 

### DIFF
--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -418,24 +418,6 @@ class KachakaApiClientByZenoh:
                 KachakaApiClient.
             json.JSONDecodeError: If the command payload is not valid JSON.
         """
-        # Check if the command is already running
-        method_name = 'command_callback'
-        try:
-            command_is_running = asyncio.run(self.run_method('is_command_running'))
-            if command_is_running:
-                self.logger.warning('Command is still running')
-                return
-            else:
-                self.logger.info('Ready to receive command')
-        except ConnectionError as e:
-            self._log_error('Connection', method_name, e)
-            return
-        except RpcError as e:
-            self._log_error('RPC', method_name, e)
-            return
-        except Exception as e:
-            self._log_error('Unexpected', method_name, e)
-
         try:
             command = json.loads(sample.payload.to_string())
             if not all(k in command for k in ('method', 'args')):
@@ -464,7 +446,9 @@ class KachakaApiClientByZenoh:
                         self.logger.warning(f'Map name {map_name} is not the same as current map {self.map_name}')
                         return
                     if 'cancel_all' not in args:
-                        args['cancel_all'] = False
+                        args['cancel_all'] = True
+                    if 'wait_for_completion' not in args:
+                        args['wait_for_completion'] = False
                     self.logger.info(f'Send move_to_pose {args=}')
                     asyncio.run(self.run_method(method_name, args))
                 else:


### PR DESCRIPTION


<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #15

<!-- 変更の詳細 -->
## Detail

RMFがリプランする際、前のCommandが完了していなくても新しいCommandが割り込んでくるため、前のActionが残っていても無視して実行する必要があります。そのため cancel_all=True を追加しました。
また、wait_for_completion=False は非同期実行のため、cancel_all=True はリプラン時に前のゴールをキャンセルするための設定です。

また、Replanの場合コマンド実行時でも上書きする可能性があるため、コマンド実行中の判定部分を削除。

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact



<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
