### PR TITLE
feat: add configurable log level and test improvements

### DIFF
--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -27,7 +27,7 @@ RUN_LINE="jupyter-lab --port=26501 --ip='0.0.0.0' & uvicorn sbgisen.rest_kachaka
 read -p "Do you want to set up the Zenoh client? (y/n) " -n 1 -r
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  read -p "Enter the Zenoh router access point: " ZENOH_ROUTER_ACCESS_POINT
+  read -p "Enter the Zenoh router access point (IP:Port, e.g., 192.168.1.100:7447): " ZENOH_ROUTER_ACCESS_POINT
   read -p "Enter the robot name: " ROBOT_NAME
   RUN_LINE="$RUN_LINE & python3 sbgisen/connect_openrmf_by_zenoh.py"
 fi

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -29,6 +29,8 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   read -p "Enter the Zenoh router access point (IP:Port, e.g., 192.168.1.100:7447): " ZENOH_ROUTER_ACCESS_POINT
   read -p "Enter the robot name: " ROBOT_NAME
+  read -p "Enter log level (DEBUG/INFO/WARNING/ERROR/CRITICAL) [INFO]: " LOG_LEVEL
+  LOG_LEVEL=${LOG_LEVEL:-INFO}
   RUN_LINE="$RUN_LINE & python3 sbgisen/connect_openrmf_by_zenoh.py"
 fi
 # Create the server setup script with dynamic KACHAKA_IP
@@ -42,6 +44,7 @@ if [ -n "$KACHAKA_IP" ]; then
 fi
 export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
+export LOG_LEVEL=$LOG_LEVEL
 export PATH=/home/kachaka/.local/bin:\$PATH
 $RUN_LINE
 EOF

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import asyncio
 import json
 import logging
@@ -68,6 +69,7 @@ class KachakaApiClientByZenoh:
         kachaka_access_point: Optional[str] = None,
         robot_name: str = 'kachaka',
         config_file: str = 'config.yaml',
+        log_level: str = 'INFO',
     ) -> None:
         """Construct method.
 
@@ -80,7 +82,10 @@ class KachakaApiClientByZenoh:
                 Defaults to 'kachaka'.
             config_file (str): The name of the configuration file to load.
                 Defaults to 'config.yaml'.
+            log_level (str): The logging level. Defaults to 'INFO'.
+                Valid values: DEBUG, INFO, WARNING, ERROR, CRITICAL.
         """
+        self.log_level = getattr(logging, log_level.upper(), logging.INFO)
         file_path = Path(__file__).resolve().parent
         config_path = file_path / '..' / 'config' if (file_path / '..' / 'config').exists() else file_path / 'config'
         with open(config_path / config_file, 'r') as f:
@@ -106,11 +111,12 @@ class KachakaApiClientByZenoh:
         self.robot_name = robot_name
         self.task_id = None
         logging.basicConfig(
-            level=logging.INFO,
+            level=self.log_level,
             format='%(asctime)s - %(levelname)s - %(message)s',
             filename='kachaka_api.log',
         )
         self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(self.log_level)
 
         # Initialize Zenoh session and publishers in constructor
         self.session = zenoh.open(self._get_zenoh_config(zenoh_router))
@@ -381,7 +387,6 @@ class KachakaApiClientByZenoh:
         Args:
             query (zenoh.Query): The received query
         """
-
         try:
             status_data = {
                 'robot_name': self.robot_name,
@@ -456,7 +461,6 @@ class KachakaApiClientByZenoh:
 
             if not hasattr(self.kachaka_client, method_name):
                 raise AttributeError(f'Invalid method: {method_name}')
-
 
             self.logger.info(f'Executing command: {method_name} (ID: {self.task_id})')
             print(f'Executing: {method_name}')
@@ -654,15 +658,28 @@ def main() -> None:
     KachakaApiClientByZenoh, subscribes to the command topic, and publishes
     the robot's pose, current map name, and command state to Zenoh in a loop.
     """
+    parser = argparse.ArgumentParser(description='Kachaka API Client for OpenRMF via Zenoh')
+    parser.add_argument(
+        '--log-level',
+        type=str,
+        default=None,
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+        help='Set the logging level (default: INFO, can also be set via LOG_LEVEL env var)',
+    )
+    args = parser.parse_args()
+
     zenoh_router_ap = os.getenv('ZENOH_ROUTER_ACCESS_POINT')
     kachaka_access_point = os.getenv('KACHAKA_ACCESS_POINT')
     robot_name = os.getenv('ROBOT_NAME', 'kachaka')
     config_file = os.getenv('CONFIG_FILE', 'config.yaml')
+    # Priority: CLI argument > environment variable > default (INFO)
+    log_level = args.log_level or os.getenv('LOG_LEVEL', 'INFO')
+
     if not zenoh_router_ap:
         raise ValueError('ZENOH_ROUTER_ACCESS_POINT must be set as an environment variable.')
 
     try:
-        node = KachakaApiClientByZenoh(zenoh_router_ap, kachaka_access_point, robot_name, config_file)
+        node = KachakaApiClientByZenoh(zenoh_router_ap, kachaka_access_point, robot_name, config_file, log_level)
 
         try:
             # Start the node with periodic command checking via Queryable pattern

--- a/test/test_kachaka_command.py
+++ b/test/test_kachaka_command.py
@@ -49,14 +49,14 @@ def create_switch_map_command(robot_name: str,
         'args': {
             'map_name': map_name,
             'pose': pose
-        }
+        },
     }
 
 
 def create_move_to_pose_command(robot_name: str,
                                 x: float,
                                 y: float,
-                                theta: float,
+                                yaw: float,
                                 map_name: Optional[str] = None) -> Dict[str, Any]:
     """Create a move_to_pose command.
 
@@ -64,13 +64,13 @@ def create_move_to_pose_command(robot_name: str,
         robot_name: Name of the robot
         x: Target x coordinate
         y: Target y coordinate
-        theta: Target orientation in radians
+        yaw: Target orientation in radians
         map_name: Optional map name (if different from current)
 
     Returns:
         Command dictionary
     """
-    args = {'x': x, 'y': y, 'theta': theta}
+    args = {'x': x, 'y': y, 'yaw': yaw}
 
     if map_name:
         args['map_name'] = map_name
@@ -103,20 +103,50 @@ def publish_command_via_queryable(zenoh_router: str, robot_name: str, command: D
     conf.insert_json5('connect/endpoints', json.dumps([f'tcp/{zenoh_router}']))
 
     session = zenoh.open(conf)
+    command_sent = False
+    command_id = command.get('id')
 
     try:
         # Declare queryable for fleet adapter simulation
         def command_handler(query: zenoh.Query) -> None:
+            nonlocal command_sent
             print(f'🔍 Received query from robot: {query.key_expr}')
             # Reply with the command
             reply_payload = json.dumps(command).encode()
             query.reply(query.key_expr, reply_payload, encoding=zenoh.Encoding.APPLICATION_JSON)
             print(f'📤 Sent command: {command}')
+            command_sent = True
+
+        # Subscribe to command completion results
+        def result_handler(sample: zenoh.Sample) -> None:
+            try:
+                result = json.loads(sample.payload.to_string())
+                result_id = result.get('id', 'unknown')
+                is_completed = result.get('is_completed', False)
+                success = result.get('success')
+                error_code = result.get('error_code')
+
+                if result_id == command_id:
+                    if is_completed:
+                        if success:
+                            print(f'✅ Command completed successfully! (id: {result_id})')
+                        else:
+                            print(f'❌ Command failed! (id: {result_id}, error_code: {error_code})')
+                    else:
+                        print(f'⏳ Command in progress... (id: {result_id})')
+                else:
+                    print(f'📨 Result for other command: {result_id}')
+            except json.JSONDecodeError:
+                print(f'⚠️ Invalid JSON in result: {sample.payload.to_string()}')
 
         queryable_key = f'robots/{robot_name}/command'
         queryable = session.declare_queryable(queryable_key, command_handler)
 
+        result_key = f'robots/{robot_name}/command_is_completed'
+        subscriber = session.declare_subscriber(result_key, result_handler)
+
         print(f'✅ Queryable declared on key: {queryable_key}')
+        print(f'✅ Subscribed to results on key: {result_key}')
         print(f'📋 Ready to send command: {json.dumps(command, indent=2)}')
         print('⏳ Waiting for robot to query for commands...')
         print('   (Robot queries every 4 seconds)')
@@ -130,6 +160,7 @@ def publish_command_via_queryable(zenoh_router: str, robot_name: str, command: D
         print('\n🛑 Stopping...')
     finally:
         queryable.undeclare()
+        subscriber.undeclare()
         session.close()
         print('✅ Cleaned up and closed Zenoh session')
 
@@ -143,7 +174,7 @@ def print_usage() -> None:
     print('    Example: python test_kachaka_command.py 127.0.0.1:7447 kachaka switch_map 27F')
     print('    Example: python test_kachaka_command.py 127.0.0.1:7447 kachaka switch_map L27 1.0 2.0 0.5')
     print()
-    print('  move_to_pose <x> <y> <theta> [map_name]')
+    print('  move_to_pose <x> <y> <yaw> [map_name]')
     print('    Example: python test_kachaka_command.py 127.0.0.1:7447 kachaka move_to_pose 1.5 2.0 0.0')
     print('    Example: python test_kachaka_command.py 127.0.0.1:7447 kachaka move_to_pose 1.5 2.0 0.0 27F')
     print()
@@ -181,16 +212,16 @@ def main() -> None:
 
         elif command_type == 'move_to_pose':
             if len(sys.argv) < 7:
-                print('❌ move_to_pose requires x, y, theta')
+                print('❌ move_to_pose requires x, y, yaw')
                 print_usage()
                 sys.exit(1)
 
             x = float(sys.argv[4])
             y = float(sys.argv[5])
-            theta = float(sys.argv[6])
+            yaw = float(sys.argv[6])
             map_name = sys.argv[7] if len(sys.argv) > 7 else None
 
-            command = create_move_to_pose_command(robot_name, x, y, theta, map_name)
+            command = create_move_to_pose_command(robot_name, x, y, yaw, map_name)
 
         elif command_type == 'dock':
             command = create_dock_command(robot_name)


### PR DESCRIPTION
## 概要
- `--log-level` CLI引数と `LOG_LEVEL` 環境変数によるログレベル設定機能を追加
- テストスクリプトの `theta` → `yaw` パラメータ名を API に合わせて修正
- テストスクリプトに `command_is_completed` subscriber を追加し、結果監視を可能に
- `kachaka_server_setup.sh` のプロンプトにフォーマット例を追加し、LOG_LEVEL 設定を追加

## テスト計画
- [x] `--log-level DEBUG` CLI引数で正しいログレベルが設定されることを確認
- [x] `LOG_LEVEL=DEBUG` 環境変数で正しいログレベルが設定されることを確認
- [x] CLI引数が環境変数より優先されることを確認
- [x] テストスクリプトを実行し、`command_is_completed` subscriber が動作することを確認
- [x] `kachaka_server_setup.sh` を実行し、プロンプトが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)