### PR TITLE
feat: add async command tracking with completion notification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install kachaka-api eclipse-zenoh pytest
+
+      - name: Show installed versions
+        run: pip freeze | grep -E "kachaka|zenoh|pytest"
+
+      - name: Run unit tests
+        run: pytest test/test_kachaka_node.py -v -m "not integration"

--- a/README.md
+++ b/README.md
@@ -199,6 +199,42 @@ python test/test_kachaka_command.py 127.0.0.1:7447 kachaka dock
 - `connect_openrmf_by_zenoh.py` must be running on the robot
 - Robot must be connected to the same Zenoh network
 
+### Unit and Integration Tests
+
+The repository includes pytest-based tests for `KachakaApiClientByZenoh`.
+
+#### Running unit tests (no hardware required)
+
+```bash
+pytest test/test_kachaka_node.py -v -m "not integration"
+```
+
+#### Running integration tests (real Kachaka required)
+
+1. Start a Zenoh router on the host PC:
+
+```bash
+bash scripts/start_zenoh_router.sh
+```
+
+2. Set environment variables and run tests:
+
+```bash
+export KACHAKA_ACCESS_POINT=<kachaka_ip>:26400
+export ZENOH_ROUTER_ACCESS_POINT=<host_ip>:7447
+pytest test/test_kachaka_node.py -v
+```
+
+To find the host IP: `hostname -I | awk '{print $1}'`
+
+#### Test categories
+
+| Class | Description | Hardware |
+|---|---|---|
+| `TestIsRunningState` | Logic for `_is_running_state()` | Not required |
+| `TestPrepareAsyncCommandArgs` | Logic for `_prepare_async_command_args()` | Not required |
+| `TestExecuteCommandTracking` | Command execution and tracking | Required |
+
 ## License
 
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for more details.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,7 @@ map_name_mapping:
 timeouts:
   command_query: 2.0        # Timeout for command queries
   grpc_connection: 5        # Wait time between gRPC connection retries
+  running_state_wait: 5.0   # Max wait time for RUNNING state after command sent
 
 intervals:
   command_check: 4.0        # How often to check for new commands

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -30,6 +30,7 @@ from google.protobuf.json_format import MessageToDict
 from grpc import RpcError
 from grpc import StatusCode
 import kachaka_api
+from kachaka_api.generated import kachaka_api_pb2 as pb2
 import yaml
 import zenoh
 
@@ -60,6 +61,9 @@ class KachakaApiClientByZenoh:
     last_command: Optional[Dict[str, Any]]
     last_command_result: Optional[Dict[str, Any]]
     last_command_id: Optional[str]
+    current_command_id: Optional[str]
+    is_async_command: bool
+    saw_running: bool
     command_check_interval: float
     logger: logging.Logger
 
@@ -102,6 +106,7 @@ class KachakaApiClientByZenoh:
 
         self.command_query_timeout = timeouts.get('command_query', 2.0)
         self.grpc_connection_sleep = timeouts.get('grpc_connection', 5)
+        self.running_state_wait = timeouts.get('running_state_wait', 5.0)
         self.command_check_interval = intervals.get('command_check', 4.0)
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
@@ -144,6 +149,9 @@ class KachakaApiClientByZenoh:
         self.last_command = None
         self.last_command_result = None
         self.last_command_id = None
+        self.current_command_id = None
+        self.is_async_command = False
+        self.saw_running = False
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -189,6 +197,21 @@ class KachakaApiClientByZenoh:
             self.logger.error(f'RPC error in {method_name}: {e.details()}')
             raise
 
+    def _log_info(self, message: str) -> None:
+        """Log info message and print to console."""
+        self.logger.info(message)
+        print(message)
+
+    def _log_warning(self, message: str) -> None:
+        """Log warning message and print to console."""
+        self.logger.warning(message)
+        print(message)
+
+    def _log_error_msg(self, message: str) -> None:
+        """Log error message and print to console."""
+        self.logger.error(message)
+        print(message)
+
     def _log_error(self, error_type: str, method_name: str, error: Exception) -> None:
         """Log an error with consistent formatting.
 
@@ -200,9 +223,7 @@ class KachakaApiClientByZenoh:
         error_msg = f'{error_type} error during {method_name}: {str(error)}'
         if isinstance(error, RpcError):
             error_msg = f'{error_type} error during {method_name}: {error.details()}'
-
-        self.logger.error(error_msg)
-        print(error_msg)
+        self._log_error_msg(error_msg)
 
     def _publish_to_zenoh(self, publisher: zenoh.Publisher, data: Union[Dict, List, str, int, float, bool]) -> bool:
         """Publish data to a Zenoh topic with consistent encoding.
@@ -214,10 +235,46 @@ class KachakaApiClientByZenoh:
         try:
             publisher.put(json.dumps(data).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
         except Exception as e:
-            self.logger.error(f'Failed to publish data to Zenoh: {str(e)}')
-            print(f'Failed to publish data to Zenoh: {str(e)}')
+            self._log_error_msg(f'Failed to publish data to Zenoh: {str(e)}')
             return False
         return True
+
+    def _get_command_state_response(self) -> Dict[str, Any]:
+        """Fetch the latest command state including command_id."""
+        try:
+            response = self.kachaka_client.stub.GetCommandState(pb2.GetRequest())
+            return MessageToDict(response)
+        except RpcError as e:
+            self._log_error('RPC', 'get_command_state', e)
+            raise
+
+    def _get_last_command_result_response(self) -> Dict[str, Any]:
+        """Fetch the most recent command result including command_id."""
+        try:
+            response = self.kachaka_client.stub.GetLastCommandResult(pb2.GetRequest())
+            return MessageToDict(response)
+        except RpcError as e:
+            self._log_error('RPC', 'get_last_command_result', e)
+            raise
+
+    def _is_running_state(self, state_value: Union[str, int, None]) -> bool:
+        """Return True if the provided state represents RUNNING."""
+        if isinstance(state_value, str):
+            return state_value.upper() == 'COMMAND_STATE_RUNNING'
+        if isinstance(state_value, int):
+            return state_value == pb2.CommandState.Value('COMMAND_STATE_RUNNING')
+        return False
+
+    def _update_current_command_id(self, response: Optional[Dict[str, Any]], method_name: str) -> None:
+        """Extract and store command_id for async commands if available."""
+        if not isinstance(response, dict):
+            return
+        command_id = response.get('commandId')
+        if command_id:
+            self.current_command_id = command_id
+            self.logger.debug(f'Captured command_id {command_id} for {method_name}')
+        else:
+            self.logger.warning(f'Async command {method_name} did not return commandId; awaiting state update')
 
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh.
@@ -240,8 +297,7 @@ class KachakaApiClientByZenoh:
                 self.last_pose = pose
             except KeyError:
                 # Handle unexpected format or missing data appropriately
-                self.logger.error(f'{pose_raw} is unexpected response format')
-                print(f'{pose_raw} is unexpected response format')
+                self._log_error_msg(f'{pose_raw} is unexpected response format')
                 return
 
             self._publish_to_zenoh(self.pose_pub, pose)
@@ -270,8 +326,7 @@ class KachakaApiClientByZenoh:
                 battery = res[0] / 100.0
                 self.last_battery = battery
             else:
-                self.logger.error(f'Unexpected battery info format: {res}')
-                print(f'Unexpected battery info format: {res}')
+                self._log_error_msg(f'Unexpected battery info format: {res}')
                 return
 
             self._publish_to_zenoh(self.battery_pub, battery)
@@ -315,48 +370,98 @@ class KachakaApiClientByZenoh:
             self._log_error('Unexpected', method_name, e)
 
     async def publish_result(self) -> None:
-        """Publish the last command completion status to Zenoh.
+        """Publish command completion status to Zenoh.
 
-        Checks the status of the most recently executed command and publishes
-        its completion status (true/false) to Zenoh along with the task ID.
-
-        Only publishes if there is an active task (task_id is set).
-        The task_id is set when a command is received via the Zenoh command topic.
-
-        The published result has the format:
-        {
-            "id": "<task_id>",
-            "is_completed": true/false
-        }
-
-        Handles connection errors and unexpected response formats.
-
-        Raises:
-            Does not raise exceptions as they are caught and logged internally.
+        Monitors active async commands and publishes their completion status.
+        Uses command_id to ensure state/result pairs belong to the active command.
         """
         method_name = 'publish_result'
         try:
             if not self.task_id:
-                # No active task to check
+                # Keep publishing last result for Pub/Sub reliability.
+                # Fleet adapter's ID check ensures stale completions are ignored.
+                if self.last_command_result:
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
                 return
 
-            res = await self.run_method('get_command_state')
-            result = {'id': self.task_id, 'is_completed': False}
+            if not self.grpc_connection_check():
+                raise ConnectionError('Failed to connect to Kachaka API server for publish_result')
 
-            if isinstance(res, (list, tuple)) and len(res) > 0 and isinstance(res[0], int):
-                result['is_completed'] = True if res[0] != 2 else False
+            state_res = self._get_command_state_response()
+            self.logger.debug(f'GetCommandState response: {state_res}')
+            command_id = state_res.get('commandId')
+            state_value = state_res.get('state')
+
+            if self.is_async_command:
+                if command_id:
+                    if self.current_command_id is None and self._is_running_state(state_value):
+                        self.current_command_id = command_id
+                        self.logger.debug(f'Bound command_id {command_id} to task {self.task_id}')
+                    elif self.current_command_id and command_id != self.current_command_id:
+                        self.logger.debug(
+                            'Ignoring command state for command_id %s (expecting %s)',
+                            command_id,
+                            self.current_command_id,
+                        )
+                        return
+                else:
+                    self.logger.debug('Command state missing commandId for task %s (state=%s)', self.task_id,
+                                      state_value)
+
+            if self._is_running_state(state_value):
+                self.saw_running = True
+                result = {'id': self.task_id, 'is_completed': False, 'success': None, 'error_code': None}
+                self.last_command_result = result
+                self._publish_to_zenoh(self.command_is_completed_pub, result)
+                return
+
+            if self.is_async_command and not self.saw_running:
+                self.logger.debug('Async command: waiting to see RUNNING state first')
+                return
+
+            last_result = self._get_last_command_result_response()
+            self.logger.debug(f'GetLastCommandResult response: {last_result}')
+            result_command_id = last_result.get('commandId')
+
+            if self.is_async_command:
+                if result_command_id:
+                    if self.current_command_id is None and self.saw_running:
+                        self.current_command_id = result_command_id
+                        self.logger.debug(f'Bound result command_id {result_command_id} to task {self.task_id}')
+                    elif self.current_command_id and result_command_id != self.current_command_id:
+                        self.logger.debug(
+                            'Ignoring result for command_id %s (expecting %s)',
+                            result_command_id,
+                            self.current_command_id,
+                        )
+                        return
+                else:
+                    self.logger.debug(f'Last command result missing commandId for task {self.task_id}')
+
+            cmd_result = last_result.get('result')
+            if not isinstance(cmd_result, dict):
+                self._log_error_msg(f'Unexpected last command result format: {last_result}')
+                result = {'id': self.task_id, 'is_completed': True, 'success': False, 'error_code': -1}
             else:
-                # Handle unexpected format or missing data appropriately
-                self.logger.error(f'Unexpected command state format: {res}')
-                print(f'Unexpected command state format: {res}')
-                return
+                success = cmd_result.get('success', False)
+                error_code = cmd_result.get('errorCode', 0)
+                result = {
+                    'id': self.task_id,
+                    'is_completed': True,
+                    'success': success,
+                    'error_code': error_code,
+                }
 
-            self.logger.debug(f'Command {self.task_id} completed: {result["is_completed"]}')
+                if success:
+                    self._log_info(f'Command {self.task_id} succeeded')
+                else:
+                    self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
+
+            # Publish and reset
             self.last_command_result = result
-            put_result = self._publish_to_zenoh(self.command_is_completed_pub, result)
-            # Reset task_id if the command is completed
-            if put_result and result['is_completed']:
-                self.task_id = None
+            if self._publish_to_zenoh(self.command_is_completed_pub, result) and result['is_completed']:
+                self._reset_async_command_state()
+
         except ConnectionError as e:
             self._log_error('Connection', method_name, e)
         except RpcError as e:
@@ -420,8 +525,7 @@ class KachakaApiClientByZenoh:
 
                         # Check if this is a new command
                         if command_id and command_id != self.last_command_id:
-                            self.logger.info(f'Received new command: {command}')
-                            print(f'New command: {command["method"]} (ID: {command_id})')
+                            self._log_info(f'New command: {command["method"]} (ID: {command_id})')
 
                             # Update last command ID to prevent duplicate processing
                             self.last_command_id = command_id
@@ -430,8 +534,7 @@ class KachakaApiClientByZenoh:
                             try:
                                 self._execute_command(command)
                             except Exception as e:
-                                self.logger.error(f'Error processing command: {str(e)}')
-                                print(f'Error processing command: {str(e)}')
+                                self._log_error_msg(f'Error processing command: {str(e)}')
                         else:
                             self.logger.debug(f'Skipping duplicate command ID: {command_id}')
                     else:
@@ -448,6 +551,30 @@ class KachakaApiClientByZenoh:
             # Wait before next check
             await asyncio.sleep(self.command_check_interval)
 
+    def _prepare_async_command_args(self,
+                                    args: Dict[str, Any],
+                                    defaults: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Prepare arguments for async StartCommand methods.
+
+        Sets wait_for_completion=False by default and updates is_async_command flag.
+
+        Args:
+            args: Original command arguments
+            defaults: Additional default values to set if not present
+
+        Returns:
+            Prepared arguments dict
+        """
+        prepared = args.copy() if args else {}
+        if defaults:
+            for key, value in defaults.items():
+                if key not in prepared:
+                    prepared[key] = value
+        if 'wait_for_completion' not in prepared:
+            prepared['wait_for_completion'] = False
+        self.is_async_command = not prepared.get('wait_for_completion', True)
+        return prepared
+
     def _execute_command(self, command: Dict[str, Any]) -> None:
         """Unified command execution logic."""
         method_name = 'execute_command'
@@ -462,32 +589,41 @@ class KachakaApiClientByZenoh:
             if not hasattr(self.kachaka_client, method_name):
                 raise AttributeError(f'Invalid method: {method_name}')
 
-            self.logger.info(f'Executing command: {method_name} (ID: {self.task_id})')
-            print(f'Executing: {method_name}')
+            self._log_info(f'Executing command: {method_name} (ID: {self.task_id})')
             self.last_command = command
             self.last_command_result = None
+            self.current_command_id = None
 
             # Execute the command
             if method_name == 'switch_map':
-                args = command['args']
-                self._execute_switch_map_sync(args)
+                self._execute_switch_map_sync(command['args'])
             elif method_name == 'move_to_pose':
-                args = command['args']
+                args = command['args'].copy()
                 map_name = args.pop('map_name', None)
                 if map_name is not None and map_name != self.map_name:
-                    self.logger.warning(f'Map name {map_name} does not match current map {self.map_name}')
+                    # Map name mismatch indicates RMF has incorrect floor information.
+                    # Reject the navigation command and return error to trigger replanning.
+                    self._log_warning(
+                        f'Map name mismatch: requested={map_name}, current={self.map_name}. '
+                        f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
+                    self._publish_command_completion(success=False, error_code=-2)
                     return
-                if 'cancel_all' not in args:
-                    args['cancel_all'] = True
-                if 'wait_for_completion' not in args:
-                    args['wait_for_completion'] = False
-                self.logger.debug(f'move_to_pose args: {args}')
-                self._execute_sync_method(method_name, args)
+                args = self._prepare_async_command_args(args, {'cancel_all': True})
+                self.logger.debug(f'Current pose: {self.last_pose}')
+                self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
+                response = self._execute_sync_method(method_name, args)
+                if self.is_async_command:
+                    self._update_current_command_id(response, method_name)
+            elif method_name == 'return_home':
+                args = self._prepare_async_command_args(command['args'])
+                response = self._execute_sync_method(method_name, args)
+                if self.is_async_command:
+                    self._update_current_command_id(response, method_name)
             else:
+                self.logger.debug(f'{method_name} args: {command["args"]}')
                 self._execute_sync_method(method_name, command['args'])
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
-            self.logger.error(f'Invalid command: {str(e)}')
-            print(f'Invalid command: {str(e)}')
+            self._log_error_msg(f'Invalid command: {str(e)}')
         except (ConnectionError, RpcError, Exception) as e:
             self._log_error('Unexpected', f'executing command {method_name}', e)
 
@@ -511,8 +647,8 @@ class KachakaApiClientByZenoh:
             map_id = next((item['id'] for item in map_list if item['name'] == map_name), None)
 
             if map_id is None:
-                self.logger.error(f'Map {map_name} not found')
-                print(f'Map {map_name} not found')
+                self._log_error_msg(f'Map {map_name} not found')
+                self._publish_command_completion(success=False, error_code=-1)
                 return
 
             current_map_id = self.kachaka_client.get_current_map_id()
@@ -522,37 +658,107 @@ class KachakaApiClientByZenoh:
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
                 self.logger.info('Nothing to do - already on target map')
+                self._publish_command_completion(success=True, error_code=0)
             else:
-                self._execute_sync_method('switch_map', payload)
-                self.logger.info(f'Switched to map {map_name}', payload['pose'])
+                response = self._execute_sync_method('switch_map', payload)
+                # Success/failure logging and notification handled by _execute_sync_method
+                # Update map_name immediately after successful switch_map
+                if response and isinstance(response, dict) and response.get('result', {}).get('success', False):
+                    self.map_name = args.get('map_name')
+                    self.logger.info(f'Updated self.map_name to {self.map_name} after successful switch_map')
         except RpcError as e:
             self._log_error('RPC', method_name, e)
+            self._publish_command_completion(success=False, error_code=-1)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
+            self._publish_command_completion(success=False, error_code=-1)
 
-    def _execute_sync_method(self, method_name: str, args: Dict[str, Any]) -> None:
-        """Execute a method synchronously without asyncio.run().
+    def _execute_sync_method(self, method_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a method synchronously and publish completion status.
 
         Args:
             method_name (str): The name of the method to execute
             args (Dict[str, Any]): The arguments for the method
+
+        Returns:
+            Dict[str, Any]: The response from the method
         """
         try:
             if not self.grpc_connection_check():
                 error_msg = f'Failed to connect to Kachaka API server for method {method_name}'
                 self.logger.error(error_msg)
+                if self.task_id:
+                    self._publish_command_completion(success=False, error_code=-1)
                 raise ConnectionError(error_msg)
 
             method = getattr(self.kachaka_client, method_name)
             response = self._to_dict(method(**args))
-            self.logger.info(f'Command {method_name} executed successfully')
+
+            # Check if response contains a 'result' field (synchronous commands return Result)
+            if isinstance(response, dict) and 'result' in response:
+                result = response['result']
+                success = result.get('success', False)
+                # Note: MessageToDict converts snake_case to camelCase
+                error_code = result.get('errorCode', 0)
+
+                if self.is_async_command and success:
+                    # Async command started, don't publish completion yet
+                    # publish_result will handle completion after RUNNING state is seen
+                    self.logger.info(f'Async command {method_name} started')
+                elif success:
+                    self.logger.info(f'Command {method_name} completed successfully')
+                    # Synchronous command completed successfully
+                    self._publish_command_completion(success=True, error_code=0)
+                else:
+                    self._log_warning(f'Command {method_name} failed with error_code={error_code}')
+                    # Always publish failure immediately
+                    self._publish_command_completion(success=False, error_code=error_code)
+            else:
+                # No result field (e.g., query methods), assume success
+                self.logger.info(f'Command {method_name} executed successfully')
+
             return response
+
         except RpcError as e:
             self.logger.error(f'RPC error in {method_name}: {e.details()}')
+            if self.task_id:
+                self._publish_command_completion(success=False, error_code=-1)
             raise
         except Exception as e:
             self.logger.error(f'Unexpected error in {method_name}: {str(e)}')
+            if self.task_id:
+                self._publish_command_completion(success=False, error_code=-1)
             raise
+
+    def _reset_async_command_state(self) -> None:
+        """Reset all async command tracking state.
+
+        Called after command completion (success or failure) to prepare
+        for the next command.
+        """
+        self.task_id = None
+        self.is_async_command = False
+        self.saw_running = False
+        self.current_command_id = None
+
+    def _publish_command_completion(self, success: bool, error_code: int) -> None:
+        """Publish command completion status to Zenoh.
+
+        Args:
+            success (bool): Whether the command succeeded
+            error_code (int): The error code (0 if success)
+        """
+        if not self.task_id:
+            return
+
+        completion_result = {'id': self.task_id, 'is_completed': True, 'success': success, 'error_code': error_code}
+
+        self.last_command_result = completion_result
+        self.logger.debug(f'Publishing command completion: {completion_result}')
+        self._publish_to_zenoh(self.command_is_completed_pub, completion_result)
+
+        # Clear all async command tracking state after publishing
+        self._reset_async_command_state()
 
     def grpc_connection_check(self, max_retries: Optional[int] = None) -> bool:
         """Check if the gRPC connection to Kachaka API server is alive.
@@ -586,8 +792,7 @@ class KachakaApiClientByZenoh:
             try:
                 self.kachaka_client.get_robot_pose()
                 if retry_count > 0:
-                    self.logger.info(f'gRPC connection restored after {retry_count} retries')
-                    print(f'gRPC connection restored after {retry_count} retries')
+                    self._log_info(f'gRPC connection restored after {retry_count} retries')
                 return True
             except RpcError as e:
                 retry_count += 1
@@ -596,19 +801,18 @@ class KachakaApiClientByZenoh:
                 self._publish_to_zenoh(self.pose_pub, self.last_pose)
                 self._publish_to_zenoh(self.battery_pub, self.last_battery)
                 self._publish_to_zenoh(self.map_name_pub, self.map_name)
+                if self.last_command_result:
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
                 if e.code() == StatusCode.UNAVAILABLE:
-                    self.logger.error(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
-                    print(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
+                    self._log_error_msg(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
                     time.sleep(sleep_time)
                 else:
-                    self.logger.error(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
-                    print(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
+                    self._log_error_msg(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
                     raise e
 
         error_details = last_error.details() if last_error else 'Unknown error'
-        self.logger.error(
+        self._log_error_msg(
             f'Failed to connect to gRPC server after {max_retries} attempts. Last error: {error_details}')
-        print(f'Failed to connect to gRPC server after {max_retries} attempts')
         return False
 
 
@@ -644,8 +848,9 @@ def _handle_main_loop_error(
         node.logger.error(f'Unexpected error in main loop: {str(error)}')
 
     if consecutive_errors >= max_consecutive_errors:
-        node.logger.error(f'Too many consecutive errors ({consecutive_errors}), exiting')
-        print(f'Too many consecutive errors ({consecutive_errors}), exiting')
+        msg = f'Too many consecutive errors ({consecutive_errors}), exiting'
+        node.logger.error(msg)
+        print(msg)
         raise error
 
     return consecutive_errors
@@ -683,8 +888,9 @@ def main() -> None:
 
         try:
             # Start the node with periodic command checking via Queryable pattern
-            print('Starting KachakaApiClientByZenoh with periodic command checking...')
-            node.logger.info('Starting KachakaApiClientByZenoh with periodic command checking...')
+            msg = 'Starting KachakaApiClientByZenoh with periodic command checking...'
+            node.logger.info(msg)
+            print(msg)
 
             consecutive_errors = 0
             max_consecutive_errors = node.max_consecutive_errors

--- a/scripts/start_zenoh_router.sh
+++ b/scripts/start_zenoh_router.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Start a Zenoh router using Docker for local development and review testing.
+#
+# Usage:
+#   ./scripts/start_zenoh_router.sh [--port PORT] [--stop] [--help]
+#
+# Examples:
+#   ./scripts/start_zenoh_router.sh                  # Start on default port 7447
+#   ./scripts/start_zenoh_router.sh --port 7448      # Start on custom port
+#   ./scripts/start_zenoh_router.sh --stop           # Stop the running router
+
+set -e
+
+CONTAINER_NAME='kachaka-zenoh-router'
+ZENOH_IMAGE='eclipse/zenoh:latest'
+DEFAULT_PORT=7447
+
+usage() {
+  echo 'Usage: ./scripts/start_zenoh_router.sh [OPTIONS]'
+  echo ''
+  echo 'Start a Zenoh router for Kachaka API development and review testing.'
+  echo ''
+  echo 'Options:'
+  echo '  --port PORT   Zenoh router port (default: 7447)'
+  echo '  --stop        Stop the running Zenoh router container'
+  echo '  --help        Show this help message'
+  echo ''
+  echo 'After starting, connect Kachaka robot with:'
+  echo "  ZENOH_ROUTER_ACCESS_POINT=<this-host-ip>:${DEFAULT_PORT}"
+  echo ''
+  echo 'Run test commands:'
+  echo '  python test/test_kachaka_command.py <this-host-ip>:7447 <robot_name> move_to_pose 1.0 0.0 0.0'
+  echo '  python test/test_kachaka_command.py <this-host-ip>:7447 <robot_name> dock'
+  echo '  python test/test_kachaka_command.py <this-host-ip>:7447 <robot_name> switch_map 27F'
+}
+
+stop_router() {
+  if docker ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
+    echo "Stopping Zenoh router container: ${CONTAINER_NAME}"
+    docker stop "${CONTAINER_NAME}"
+    echo 'Zenoh router stopped.'
+  else
+    echo 'Zenoh router is not running.'
+  fi
+}
+
+PORT=${DEFAULT_PORT}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --port)
+      PORT="$2"
+      shift 2
+      ;;
+    --stop)
+      stop_router
+      exit 0
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v docker &> /dev/null; then
+  echo 'Error: Docker is not installed or not in PATH.'
+  echo 'Install Docker: https://docs.docker.com/get-docker/'
+  exit 1
+fi
+
+# Stop existing container if running
+if docker ps -q --filter "name=${CONTAINER_NAME}" | grep -q .; then
+  echo "Stopping existing Zenoh router container..."
+  docker stop "${CONTAINER_NAME}" > /dev/null
+fi
+
+# Remove existing container if it exists
+if docker ps -aq --filter "name=${CONTAINER_NAME}" | grep -q .; then
+  docker rm "${CONTAINER_NAME}" > /dev/null
+fi
+
+HOST_IP=$(hostname -I | awk '{print $1}')
+
+echo "Starting Zenoh router on port ${PORT}..."
+docker run -d \
+  --name "${CONTAINER_NAME}" \
+  --network host \
+  "${ZENOH_IMAGE}" \
+  --listen "tcp/0.0.0.0:${PORT}"
+
+echo ''
+echo 'Zenoh router started successfully.'
+echo ''
+echo "  Router address for Kachaka robot: ${HOST_IP}:${PORT}"
+echo ''
+echo 'Next steps:'
+echo "  1. Run kachaka_server_setup.sh with ZENOH_ROUTER_ACCESS_POINT=${HOST_IP}:${PORT}"
+echo "  2. Test with: python test/test_kachaka_command.py ${HOST_IP}:${PORT} <robot_name> <command>"
+echo ''
+echo "To stop: ./scripts/start_zenoh_router.sh --stop"

--- a/test/test_kachaka_node.py
+++ b/test/test_kachaka_node.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for KachakaApiClientByZenoh.
+
+Test categories:
+  - Pure logic tests: no external dependencies, runnable in CI.
+  - Integration tests: require KACHAKA_ACCESS_POINT and
+    ZENOH_ROUTER_ACCESS_POINT environment variables (real robot on LAN).
+
+Running integration tests:
+  export KACHAKA_ACCESS_POINT=192.168.128.30:26400
+  export ZENOH_ROUTER_ACCESS_POINT=192.168.1.100:7447
+  pytest test/test_kachaka_node.py -v
+
+Running only pure logic tests (CI):
+  pytest test/test_kachaka_node.py -v -m "not integration"
+"""
+
+import asyncio
+import os
+from pathlib import Path
+import sys
+from typing import Generator
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / 'scripts'))
+
+from connect_openrmf_by_zenoh import KachakaApiClientByZenoh  # noqa: E402
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_node() -> KachakaApiClientByZenoh:
+    """KachakaApiClientByZenoh with all external connections mocked.
+
+    Use this fixture for pure logic tests that do not require a real robot
+    or Zenoh router.
+    """
+    mock_session = MagicMock()
+    mock_session.declare_publisher.return_value = MagicMock()
+    mock_session.declare_queryable.return_value = MagicMock()
+    mock_session.declare_querier.return_value = MagicMock()
+    with (
+            patch('zenoh.open', return_value=mock_session),
+            patch('kachaka_api.KachakaApiClient', return_value=MagicMock()),
+    ):
+        node = KachakaApiClientByZenoh(
+            zenoh_router='127.0.0.1:7447',
+            kachaka_access_point='127.0.0.1:26400',
+        )
+    return node
+
+
+@pytest.fixture
+def real_node() -> Generator[KachakaApiClientByZenoh, None, None]:
+    """KachakaApiClientByZenoh connected to a real Kachaka robot on the LAN.
+
+    Requires the following environment variables:
+      KACHAKA_ACCESS_POINT      e.g. 192.168.128.30:26400
+      ZENOH_ROUTER_ACCESS_POINT e.g. 192.168.1.100:7447
+
+    Start the Zenoh router with:
+      ./scripts/start_zenoh_router.sh
+    """
+    kachaka_ap = os.environ.get('KACHAKA_ACCESS_POINT')
+    zenoh_router = os.environ.get('ZENOH_ROUTER_ACCESS_POINT')
+    if not kachaka_ap or not zenoh_router:
+        pytest.skip('Set KACHAKA_ACCESS_POINT and ZENOH_ROUTER_ACCESS_POINT to run integration tests')
+    node = KachakaApiClientByZenoh(zenoh_router=zenoh_router, kachaka_access_point=kachaka_ap)
+    yield node
+    node.session.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pure logic tests (no external dependencies)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsRunningState:
+    """Tests for _is_running_state().
+
+    Verifies that both string and int representations of the RUNNING state
+    are correctly identified.
+    """
+
+    def test_running_string(self, mock_node: KachakaApiClientByZenoh) -> None:
+        assert mock_node._is_running_state('COMMAND_STATE_RUNNING') is True  # noqa: SLF001
+
+    def test_running_string_case_insensitive(self, mock_node: KachakaApiClientByZenoh) -> None:
+        assert mock_node._is_running_state('command_state_running') is True  # noqa: SLF001
+
+    def test_non_running_string(self, mock_node: KachakaApiClientByZenoh) -> None:
+        assert mock_node._is_running_state('COMMAND_STATE_SUCCEEDED') is False  # noqa: SLF001
+
+    def test_none_returns_false(self, mock_node: KachakaApiClientByZenoh) -> None:
+        assert mock_node._is_running_state(None) is False  # noqa: SLF001
+
+    def test_empty_string_returns_false(self, mock_node: KachakaApiClientByZenoh) -> None:
+        assert mock_node._is_running_state('') is False  # noqa: SLF001
+
+
+class TestPrepareAsyncCommandArgs:
+    """Tests for _prepare_async_command_args().
+
+    Verifies argument preparation for async StartCommand calls:
+    wait_for_completion defaults to False and is_async_command flag is updated.
+    """
+
+    def test_sets_wait_for_completion_false_by_default(self, mock_node: KachakaApiClientByZenoh) -> None:
+        result = mock_node._prepare_async_command_args({})  # noqa: SLF001
+        assert result['wait_for_completion'] is False
+        assert mock_node.is_async_command is True
+
+    def test_preserves_explicit_wait_for_completion_true(self, mock_node: KachakaApiClientByZenoh) -> None:
+        result = mock_node._prepare_async_command_args({'wait_for_completion': True})  # noqa: SLF001
+        assert result['wait_for_completion'] is True
+        assert mock_node.is_async_command is False
+
+    def test_applies_defaults_when_key_missing(self, mock_node: KachakaApiClientByZenoh) -> None:
+        result = mock_node._prepare_async_command_args({}, defaults={'speed': 1.0})  # noqa: SLF001
+        assert result['speed'] == 1.0
+
+    def test_does_not_override_existing_key_with_default(self, mock_node: KachakaApiClientByZenoh) -> None:
+        result = mock_node._prepare_async_command_args({'speed': 0.5}, defaults={'speed': 1.0})  # noqa: SLF001
+        assert result['speed'] == 0.5
+
+    def test_does_not_mutate_original_args(self, mock_node: KachakaApiClientByZenoh) -> None:
+        original = {'x': 1.0}
+        mock_node._prepare_async_command_args(original)  # noqa: SLF001
+        assert 'wait_for_completion' not in original
+
+    def test_none_args_returns_dict_with_wait_for_completion(self, mock_node: KachakaApiClientByZenoh) -> None:
+        result = mock_node._prepare_async_command_args(None)  # noqa: SLF001
+        assert 'wait_for_completion' in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration tests (real Kachaka + Zenoh router required)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+class TestExecuteCommandTracking:
+    """Integration tests for command_id-based tracking in _execute_command().
+
+    These tests require a real Kachaka robot accessible on the LAN.
+    Start the Zenoh router with ./scripts/start_zenoh_router.sh before running.
+    """
+
+    def test_wrong_map_returns_error_code_minus_2(self, real_node: KachakaApiClientByZenoh) -> None:
+        """_execute_command with an unknown map_name must set error_code=-2 immediately."""
+        command = {
+            'id': 'test_wrong_map',
+            'method': 'move_to_pose',
+            'args': {
+                'x': 0.0,
+                'y': 0.0,
+                'yaw': 0.0,
+                'map_name': 'NON_EXISTENT_MAP_FOR_TESTING',
+            },
+        }
+        real_node._execute_command(command)  # noqa: SLF001
+        assert real_node.last_command_result is not None
+        assert real_node.last_command_result.get('error_code') == -2
+
+    def test_command_id_set_after_async_command(self, real_node: KachakaApiClientByZenoh) -> None:
+        """current_command_id must be populated after move_to_pose is dispatched."""
+        command = {
+            'id': 'test_cmd_id_tracking',
+            'method': 'move_to_pose',
+            'args': {
+                'x': 0.0,
+                'y': 0.0,
+                'yaw': 0.0
+            },
+        }
+        real_node._execute_command(command)  # noqa: SLF001
+        assert real_node.current_command_id is not None
+
+    def test_stale_command_id_does_not_trigger_completion(self, real_node: KachakaApiClientByZenoh) -> None:
+        """Results for a stale command_id must not be published as completion.
+
+        Sends a command then overwrites current_command_id with a fake value.
+        publish_result must not mark the stale command as completed.
+        """
+        command = {
+            'id': 'test_stale_cmd',
+            'method': 'move_to_pose',
+            'args': {
+                'x': 0.0,
+                'y': 0.0,
+                'yaw': 0.0
+            },
+        }
+        real_node._execute_command(command)  # noqa: SLF001
+        real_node.current_command_id = 'stale_id_that_will_never_match'
+        asyncio.run(real_node.publish_result())
+        result = real_node.last_command_result
+        if result is not None:
+            assert result.get('id') != 'stale_id_that_will_never_match' or result.get('is_completed') is False


### PR DESCRIPTION
## 概要
- 非同期コマンド（move_to_pose, return_home）の command_id ベース追跡を追加し、状態/結果の対応を保証
- `_publish_command_completion` による同期的な完了通知をフリートアダプターに送信
- `publish_result` を command_id 検証、`saw_running` チェック、gRPC 切断耐性で改修
- `_execute_command` にマップ名検証と非同期コマンド引数準備を追加
- ヘルパーメソッド追加: `_get_command_state_response`, `_get_last_command_result_response`, `_is_running_state`, `_update_current_command_id`, `_prepare_async_command_args`, `_reset_async_command_state`
- `_log_info`, `_log_warning`, `_log_error_msg` ログユーティリティを追加
- `running_state_wait` タイムアウト設定を追加

## テスト計画
- [x] move_to_pose コマンドが RUNNING 中に `is_completed: false` を publish することを確認
- [x] move_to_pose コマンドが完了後に `is_completed: true` と success/error を publish することを確認
- [x] command_id 不一致が正しく無視されることを確認（誤った完了通知が出ないこと）
- [x] マップ名不一致時に error_code -2 でナビゲーションが拒否されることを確認
- [x] switch_map が完了通知を publish することを確認
- [x] コマンド実行中の gRPC 切断が適切にハンドリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)