### PR TITLE
コマンド完了処理の不整合を修正

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -25,5 +25,13 @@ connection:
   max_retries: 20           # Max gRPC connection retries
   max_consecutive_errors: 10  # Exit after this many consecutive errors
 
+# Navigation retry settings
+navigation_retry:
+  enabled: true             # Enable automatic retry on navigation failure
+  max_retries: 3            # Maximum number of retry attempts
+  retry_interval: 2.0       # Wait time (seconds) before retrying
+  retry_on_error_types:     # Error types that trigger automatic retry
+    - Error                 # Retriable errors (may succeed on retry)
+
 # Optional: Custom Zenoh config file path
 # zenoh_config: "/path/to/zenoh.json5"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,7 @@ map_name_mapping:
 timeouts:
   command_query: 2.0        # Timeout for command queries
   grpc_connection: 5        # Wait time between gRPC connection retries
+  running_state_wait: 5.0   # Max wait time for RUNNING state after command sent
 
 intervals:
   command_check: 4.0        # How often to check for new commands

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -15,6 +15,8 @@ timeouts:
   command_query: 2.0        # Timeout for command queries
   grpc_connection: 5        # Wait time between gRPC connection retries
   running_state_wait: 5.0   # Max wait time for RUNNING state after command sent
+  grpc_telemetry: 5.0       # Timeout for telemetry gRPC calls (get_robot_pose, etc.)
+  grpc_status_check: 5.0    # Timeout for command status gRPC calls (GetCommandState, etc.)
 
 intervals:
   command_check: 4.0        # How often to check for new commands

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -165,6 +165,7 @@ class KachakaApiClientByZenoh:
         self.is_async_command = False
         self.saw_running = False
         self.retry_count = 0
+        self._command_lock = threading.RLock()
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -418,93 +419,91 @@ class KachakaApiClientByZenoh:
         """
         method_name = 'publish_result'
         try:
-            if not self.task_id:
-                # Keep publishing last result for Pub/Sub reliability.
-                # Fleet adapter's ID check ensures stale completions are ignored.
-                if self.last_command_result:
-                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
-                return
+            with self._command_lock:
+                if not self.task_id:
+                    # Keep publishing last result for Pub/Sub reliability.
+                    # Fleet adapter's ID check ensures stale completions are ignored.
+                    if self.last_command_result:
+                        self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
+                    return
 
-            if not self.grpc_connection_check():
-                raise ConnectionError('Failed to connect to Kachaka API server for publish_result')
+                state_res = self._get_command_state_response()
+                self.logger.debug(f'GetCommandState response: {state_res}')
+                command_id = state_res.get('commandId')
+                state_value = state_res.get('state')
 
-            state_res = self._get_command_state_response()
-            self.logger.debug(f'GetCommandState response: {state_res}')
-            command_id = state_res.get('commandId')
-            state_value = state_res.get('state')
+                if self.is_async_command:
+                    if command_id:
+                        if self.current_command_id is None and self._is_running_state(state_value):
+                            self.current_command_id = command_id
+                            self.logger.debug(f'Bound command_id {command_id} to task {self.task_id}')
+                        elif self.current_command_id and command_id != self.current_command_id:
+                            self.logger.debug(
+                                'Ignoring command state for command_id %s (expecting %s)',
+                                command_id,
+                                self.current_command_id,
+                            )
+                            return
+                    else:
+                        self.logger.debug('Command state missing commandId for task %s (state=%s)', self.task_id,
+                                          state_value)
 
-            if self.is_async_command:
-                if command_id:
-                    if self.current_command_id is None and self._is_running_state(state_value):
-                        self.current_command_id = command_id
-                        self.logger.debug(f'Bound command_id {command_id} to task {self.task_id}')
-                    elif self.current_command_id and command_id != self.current_command_id:
-                        self.logger.debug(
-                            'Ignoring command state for command_id %s (expecting %s)',
-                            command_id,
-                            self.current_command_id,
-                        )
-                        return
+                if self._is_running_state(state_value):
+                    self.saw_running = True
+                    result = {'id': self.task_id, 'is_completed': False, 'success': None, 'error_code': None}
+                    self.last_command_result = result
+                    self._publish_to_zenoh(self.command_is_completed_pub, result)
+                    return
+
+                if self.is_async_command and not self.saw_running:
+                    self.logger.debug('Async command: waiting to see RUNNING state first')
+                    return
+
+                last_result = self._get_last_command_result_response()
+                self.logger.debug(f'GetLastCommandResult response: {last_result}')
+                result_command_id = last_result.get('commandId')
+
+                if self.is_async_command:
+                    if result_command_id:
+                        if self.current_command_id is None and self.saw_running:
+                            self.current_command_id = result_command_id
+                            self.logger.debug(f'Bound result command_id {result_command_id} to task {self.task_id}')
+                        elif self.current_command_id and result_command_id != self.current_command_id:
+                            self.logger.debug(
+                                'Ignoring result for command_id %s (expecting %s)',
+                                result_command_id,
+                                self.current_command_id,
+                            )
+                            return
+                    else:
+                        self.logger.debug(f'Last command result missing commandId for task {self.task_id}')
+
+                cmd_result = last_result.get('result')
+                if not isinstance(cmd_result, dict):
+                    self._log_error_msg(f'Unexpected last command result format: {last_result}')
+                    result = {'id': self.task_id, 'is_completed': True, 'success': False, 'error_code': -1}
                 else:
-                    self.logger.debug('Command state missing commandId for task %s (state=%s)', self.task_id,
-                                      state_value)
+                    success = cmd_result.get('success', False)
+                    error_code = cmd_result.get('errorCode', 0)
+                    result = {
+                        'id': self.task_id,
+                        'is_completed': True,
+                        'success': success,
+                        'error_code': error_code,
+                    }
 
-            if self._is_running_state(state_value):
-                self.saw_running = True
-                result = {'id': self.task_id, 'is_completed': False, 'success': None, 'error_code': None}
+                    if success:
+                        self._log_info(f'Command {self.task_id} succeeded')
+                        self.retry_count = 0
+                    else:
+                        self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
+                        if await self._handle_command_retry(error_code):
+                            return  # Retry initiated, don't publish yet
+
+                # Publish and reset
                 self.last_command_result = result
-                self._publish_to_zenoh(self.command_is_completed_pub, result)
-                return
-
-            if self.is_async_command and not self.saw_running:
-                self.logger.debug('Async command: waiting to see RUNNING state first')
-                return
-
-            last_result = self._get_last_command_result_response()
-            self.logger.debug(f'GetLastCommandResult response: {last_result}')
-            result_command_id = last_result.get('commandId')
-
-            if self.is_async_command:
-                if result_command_id:
-                    if self.current_command_id is None and self.saw_running:
-                        self.current_command_id = result_command_id
-                        self.logger.debug(f'Bound result command_id {result_command_id} to task {self.task_id}')
-                    elif self.current_command_id and result_command_id != self.current_command_id:
-                        self.logger.debug(
-                            'Ignoring result for command_id %s (expecting %s)',
-                            result_command_id,
-                            self.current_command_id,
-                        )
-                        return
-                else:
-                    self.logger.debug(f'Last command result missing commandId for task {self.task_id}')
-
-            cmd_result = last_result.get('result')
-            if not isinstance(cmd_result, dict):
-                self._log_error_msg(f'Unexpected last command result format: {last_result}')
-                result = {'id': self.task_id, 'is_completed': True, 'success': False, 'error_code': -1}
-            else:
-                success = cmd_result.get('success', False)
-                error_code = cmd_result.get('errorCode', 0)
-                result = {
-                    'id': self.task_id,
-                    'is_completed': True,
-                    'success': success,
-                    'error_code': error_code,
-                }
-
-                if success:
-                    self._log_info(f'Command {self.task_id} succeeded')
-                    self.retry_count = 0
-                else:
-                    self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
-                    if await self._handle_command_retry(error_code):
-                        return  # Retry initiated, don't publish yet
-
-            # Publish and reset
-            self.last_command_result = result
-            if self._publish_to_zenoh(self.command_is_completed_pub, result) and result['is_completed']:
-                self._reset_async_command_state()
+                if self._publish_to_zenoh(self.command_is_completed_pub, result) and result['is_completed']:
+                    self._reset_async_command_state()
 
         except ConnectionError as e:
             self._log_error('Connection', method_name, e)
@@ -666,50 +665,51 @@ class KachakaApiClientByZenoh:
         """Unified command execution logic."""
         method_name = 'execute_command'
         try:
-            if not all(k in command for k in ('method', 'args')):
-                raise ValueError('Invalid command structure')
+            with self._command_lock:
+                if not all(k in command for k in ('method', 'args')):
+                    raise ValueError('Invalid command structure')
 
-            method_name = command['method']
-            method_name = self.method_mapping.get(method_name, method_name)
-            self.task_id = command.get('id', None)
+                method_name = command['method']
+                method_name = self.method_mapping.get(method_name, method_name)
+                self.task_id = command.get('id', None)
 
-            if not hasattr(self.kachaka_client, method_name):
-                raise AttributeError(f'Invalid method: {method_name}')
+                if not hasattr(self.kachaka_client, method_name):
+                    raise AttributeError(f'Invalid method: {method_name}')
 
-            self._log_info(f'Executing command: {method_name} (ID: {self.task_id})')
-            self.last_command = command
-            self.last_command_result = None
-            self.current_command_id = None
-            self.retry_count = 0
+                self._log_info(f'Executing command: {method_name} (ID: {self.task_id})')
+                self.last_command = command
+                self.last_command_result = None
+                self.current_command_id = None
+                self.retry_count = 0
 
-            # Execute the command
-            if method_name == 'switch_map':
-                self._execute_switch_map_sync(command['args'])
-            elif method_name == 'move_to_pose':
-                args = command['args'].copy()
-                map_name = args.pop('map_name', None)
-                if map_name is not None and map_name != self.map_name:
-                    # Map name mismatch indicates RMF has incorrect floor information.
-                    # Reject the navigation command and return error to trigger replanning.
-                    self._log_warning(
-                        f'Map name mismatch: requested={map_name}, current={self.map_name}. '
-                        f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
-                    self._publish_command_completion(success=False, error_code=-2)
-                    return
-                args = self._prepare_async_command_args(args, {'cancel_all': True})
-                self.logger.debug(f'Current pose: {self.last_pose}')
-                self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
-                response = self._execute_sync_method(method_name, args)
-                if self.is_async_command:
-                    self._update_current_command_id(response, method_name)
-            elif method_name == 'return_home':
-                args = self._prepare_async_command_args(command['args'])
-                response = self._execute_sync_method(method_name, args)
-                if self.is_async_command:
-                    self._update_current_command_id(response, method_name)
-            else:
-                self.logger.debug(f'{method_name} args: {command["args"]}')
-                self._execute_sync_method(method_name, command['args'])
+                # Execute the command
+                if method_name == 'switch_map':
+                    self._execute_switch_map_sync(command['args'])
+                elif method_name == 'move_to_pose':
+                    args = command['args'].copy()
+                    map_name = args.pop('map_name', None)
+                    if map_name is not None and map_name != self.map_name:
+                        # Map name mismatch indicates RMF has incorrect floor information.
+                        # Reject the navigation command and return error to trigger replanning.
+                        self._log_warning(
+                            f'Map name mismatch: requested={map_name}, current={self.map_name}. '
+                            f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
+                        self._publish_command_completion(success=False, error_code=-2)
+                        return
+                    args = self._prepare_async_command_args(args, {'cancel_all': True})
+                    self.logger.debug(f'Current pose: {self.last_pose}')
+                    self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
+                    response = self._execute_sync_method(method_name, args)
+                    if self.is_async_command:
+                        self._update_current_command_id(response, method_name)
+                elif method_name == 'return_home':
+                    args = self._prepare_async_command_args(command['args'])
+                    response = self._execute_sync_method(method_name, args)
+                    if self.is_async_command:
+                        self._update_current_command_id(response, method_name)
+                else:
+                    self.logger.debug(f'{method_name} args: {command["args"]}')
+                    self._execute_sync_method(method_name, command['args'])
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
             self._log_error_msg(f'Invalid command: {str(e)}')
         except (ConnectionError, RpcError, Exception) as e:

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -182,11 +182,8 @@ class KachakaApiClientByZenoh:
         self.max_navigation_retries = navigation_retry.get('max_retries', 3)
         self.retry_interval = navigation_retry.get('retry_interval', 2.0)
         self.retry_on_error_types = navigation_retry.get('retry_on_error_types', ['Error'])
-        self.kachaka_client = (
-            kachaka_api.KachakaApiClient(kachaka_access_point)
-            if kachaka_access_point
-            else kachaka_api.KachakaApiClient()
-        )
+        self.kachaka_client = (kachaka_api.KachakaApiClient(kachaka_access_point)
+                               if kachaka_access_point else kachaka_api.KachakaApiClient())
         self.robot_name = robot_name
         self.task_id = None
         logging.basicConfig(
@@ -203,13 +200,11 @@ class KachakaApiClientByZenoh:
         self.battery_pub = self.session.declare_publisher(f'robots/{self.robot_name}/battery')
         self.map_name_pub = self.session.declare_publisher(f'robots/{self.robot_name}/map_name')
         self.command_is_completed_pub = self.session.declare_publisher(
-            f'robots/{self.robot_name}/command_is_completed'
-        )
+            f'robots/{self.robot_name}/command_is_completed')
 
         # Initialize queryable for request-reply pattern
-        self.status_queryable = self.session.declare_queryable(
-            f'robots/{self.robot_name}/status', self._status_query_handler
-        )
+        self.status_queryable = self.session.declare_queryable(f'robots/{self.robot_name}/status',
+                                                               self._status_query_handler)
 
         # Initialize querier for fetching commands from fleet adapter
         self.command_querier = self.session.declare_querier(
@@ -322,9 +317,8 @@ class KachakaApiClientByZenoh:
     def _get_command_state_response(self) -> Dict[str, Any]:
         """Fetch the latest command state including command_id."""
         try:
-            response = self.kachaka_client.stub.GetCommandState(
-                pb2.GetRequest(), timeout=self.grpc_status_check_timeout
-            )
+            response = self.kachaka_client.stub.GetCommandState(pb2.GetRequest(),
+                                                                timeout=self.grpc_status_check_timeout)
             return MessageToDict(response)
         except RpcError as e:
             self._log_error('RPC', 'get_command_state', e)
@@ -333,9 +327,8 @@ class KachakaApiClientByZenoh:
     def _get_last_command_result_response(self) -> Dict[str, Any]:
         """Fetch the most recent command result including command_id."""
         try:
-            response = self.kachaka_client.stub.GetLastCommandResult(
-                pb2.GetRequest(), timeout=self.grpc_status_check_timeout
-            )
+            response = self.kachaka_client.stub.GetLastCommandResult(pb2.GetRequest(),
+                                                                     timeout=self.grpc_status_check_timeout)
             return MessageToDict(response)
         except RpcError as e:
             self._log_error('RPC', 'get_last_command_result', e)
@@ -420,16 +413,15 @@ class KachakaApiClientByZenoh:
         """
         method_name = 'publish_map_name'
         try:
-            map_list_response = self.kachaka_client.stub.GetMapList(
-                pb2.GetRequest(), timeout=self.grpc_telemetry_timeout
-            )
-            map_id_response = self.kachaka_client.stub.GetCurrentMapId(
-                pb2.GetRequest(), timeout=self.grpc_telemetry_timeout
-            )
+            map_list_response = self.kachaka_client.stub.GetMapList(pb2.GetRequest(),
+                                                                    timeout=self.grpc_telemetry_timeout)
+            map_id_response = self.kachaka_client.stub.GetCurrentMapId(pb2.GetRequest(),
+                                                                       timeout=self.grpc_telemetry_timeout)
 
             search_id = map_id_response.id
             kachaka_map_name = next(
-                (entry.name for entry in map_list_response.map_list_entries if entry.id == search_id), 'L1'
+                (entry.name for entry in map_list_response.map_list_entries if entry.id == search_id),
+                'L1',
             )
             map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
             self.map_state = self.map_state.with_telemetry_map_name(map_name)
@@ -488,7 +480,10 @@ class KachakaApiClientByZenoh:
                     # Keep publishing last result for Pub/Sub reliability.
                     # Fleet adapter's ID check ensures stale completions are ignored.
                     if self.last_command_result:
-                        self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+                        self._publish_to_zenoh(
+                            self.command_is_completed_pub,
+                            self.last_command_result.as_payload(),
+                        )
                     return
 
                 state_res = self._get_command_state_response()
@@ -510,7 +505,9 @@ class KachakaApiClientByZenoh:
                             return
                     else:
                         self.logger.debug(
-                            'Command state missing commandId for task %s (state=%s)', self.task_id, state_value
+                            'Command state missing commandId for task %s (state=%s)',
+                            self.task_id,
+                            state_value,
                         )
 
                 if self._is_running_state(state_value):
@@ -528,10 +525,8 @@ class KachakaApiClientByZenoh:
                 if self.is_async_command and not self.saw_running:
                     if self.current_command_id is None and command_id and self._running_state_wait_expired():
                         self.current_command_id = command_id
-                        self._log_warning(
-                            f'RUNNING state was not observed within {self.running_state_wait}s; '
-                            f'falling back to command_id={command_id} for task {self.task_id}'
-                        )
+                        self._log_warning(f'RUNNING state was not observed within {self.running_state_wait}s; '
+                                          f'falling back to command_id={command_id} for task {self.task_id}')
                     elif self.current_command_id is None:
                         self.logger.debug('Async command: waiting to see RUNNING state first')
                         return
@@ -641,8 +636,8 @@ class KachakaApiClientByZenoh:
             return True
 
     def _to_dict(
-        self, response: Union[dict, list, RepeatedCompositeContainer, object]
-    ) -> Union[dict, list, RepeatedCompositeContainer]:
+        self, response: Union[dict, list, RepeatedCompositeContainer,
+                              object]) -> Union[dict, list, RepeatedCompositeContainer]:
         """Convert a response object to a dictionary or list.
 
         Args:
@@ -709,9 +704,8 @@ class KachakaApiClientByZenoh:
                         else:
                             self.logger.debug(f'Skipping duplicate command ID: {command_id}')
                     else:
-                        error_payload = (
-                            reply.err.payload.to_string() if reply.err and reply.err.payload else 'Unknown error'
-                        )
+                        error_payload = (reply.err.payload.to_string()
+                                         if reply.err and reply.err.payload else 'Unknown error')
                         if error_payload == 'Timeout':
                             self.logger.debug('Query timeout (normal if no new commands)')
                         else:
@@ -723,9 +717,9 @@ class KachakaApiClientByZenoh:
             # Wait before next check
             await asyncio.sleep(self.command_check_interval)
 
-    def _prepare_async_command_args(
-        self, args: Dict[str, Any], defaults: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+    def _prepare_async_command_args(self,
+                                    args: Dict[str, Any],
+                                    defaults: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Prepare arguments for async StartCommand methods.
 
         Sets wait_for_completion=False by default and updates is_async_command flag.
@@ -790,18 +784,14 @@ class KachakaApiClientByZenoh:
                 elif method_name == 'move_to_pose':
                     args = command['args'].copy()
                     map_name = args.pop('map_name', None)
-                    if (
-                        map_name is not None
-                        and self._command_context_map_name is not None
-                        and map_name != self._command_context_map_name
-                    ):
+                    if (map_name is not None and self._command_context_map_name is not None and
+                            map_name != self._command_context_map_name):
                         # Map name mismatch indicates RMF has incorrect floor information.
                         # Reject the navigation command and return error to trigger replanning.
                         self._log_warning(
                             f'Map name mismatch: requested={map_name}, '
                             f'current={self._command_context_map_name}. '
-                            f'Rejecting navigation command to prevent navigation to wrong floor coordinates.'
-                        )
+                            f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
                         self._publish_command_completion(success=False, error_code=-2)
                         return
                     args = self._prepare_async_command_args(args, {'cancel_all': True})
@@ -848,7 +838,14 @@ class KachakaApiClientByZenoh:
                 return
 
             current_map_id = self.kachaka_client.get_current_map_id()
-            payload = {'map_id': map_id, 'pose': args.get('pose', {'x': 0.0, 'y': 0.0, 'theta': 0.0})}
+            payload = {
+                'map_id': map_id,
+                'pose': args.get('pose', {
+                    'x': 0.0,
+                    'y': 0.0,
+                    'theta': 0.0
+                }),
+            }
 
             # switch map only if the map is different from the current map id
             # because switch_map method takes long time to complete
@@ -1018,7 +1015,10 @@ class KachakaApiClientByZenoh:
                 self._publish_to_zenoh(self.battery_pub, self.last_battery)
                 self._publish_to_zenoh(self.map_name_pub, self.map_state.telemetry_map_name)
                 if self.last_command_result:
-                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+                    self._publish_to_zenoh(
+                        self.command_is_completed_pub,
+                        self.last_command_result.as_payload(),
+                    )
                 if e.code() == StatusCode.UNAVAILABLE:
                     self._log_error_msg(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
                     time.sleep(sleep_time)
@@ -1028,49 +1028,8 @@ class KachakaApiClientByZenoh:
 
         error_details = last_error.details() if last_error else 'Unknown error'
         self._log_error_msg(
-            f'Failed to connect to gRPC server after {max_retries} attempts. Last error: {error_details}'
-        )
+            f'Failed to connect to gRPC server after {max_retries} attempts. Last error: {error_details}')
         return False
-
-
-def _handle_main_loop_error(
-    node: KachakaApiClientByZenoh,
-    error: Exception,
-    consecutive_errors: int,
-    max_consecutive_errors: int,
-) -> int:
-    """Handle errors in the main loop.
-
-    Args:
-        node: The KachakaApiClientByZenoh node instance
-        error: The exception that was raised
-        consecutive_errors: Current count of consecutive errors
-        max_consecutive_errors: Maximum allowed consecutive errors
-
-    Returns:
-        int: Updated consecutive_errors count
-
-    Raises:
-        Exception: If too many consecutive errors occur
-    """
-    consecutive_errors += 1
-    if isinstance(error, RpcError) and error.code() == StatusCode.UNAVAILABLE:
-        node.logger.error(f'Connection RPC error in main loop: {error.details()}')
-    elif isinstance(error, ConnectionError):
-        node.logger.error(f'Connection error in main loop: {str(error)}')
-    elif isinstance(error, RpcError):
-        node.logger.error(f'Unexpected RPC error in main loop: {error.details()}')
-        raise error
-    else:
-        node.logger.error(f'Unexpected error in main loop: {str(error)}')
-
-    if consecutive_errors >= max_consecutive_errors:
-        msg = f'Too many consecutive errors ({consecutive_errors}), exiting'
-        node.logger.error(msg)
-        print(msg)
-        raise error
-
-    return consecutive_errors
 
 
 def main() -> None:

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -66,6 +66,11 @@ class KachakaApiClientByZenoh:
     saw_running: bool
     command_check_interval: float
     logger: logging.Logger
+    retry_enabled: bool
+    max_navigation_retries: int
+    retry_interval: float
+    retry_on_error_types: List[str]
+    retry_count: int
 
     def __init__(
         self,
@@ -103,6 +108,7 @@ class KachakaApiClientByZenoh:
         timeouts = config.get('timeouts', {})
         intervals = config.get('intervals', {})
         connection = config.get('connection', {})
+        navigation_retry = config.get('navigation_retry', {})
 
         self.command_query_timeout = timeouts.get('command_query', 2.0)
         self.grpc_connection_sleep = timeouts.get('grpc_connection', 5)
@@ -111,6 +117,12 @@ class KachakaApiClientByZenoh:
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
         self.max_consecutive_errors = connection.get('max_consecutive_errors', 10)
+
+        # Load navigation retry settings
+        self.retry_enabled = navigation_retry.get('enabled', True)
+        self.max_navigation_retries = navigation_retry.get('max_retries', 3)
+        self.retry_interval = navigation_retry.get('retry_interval', 2.0)
+        self.retry_on_error_types = navigation_retry.get('retry_on_error_types', ['Error'])
         self.kachaka_client = (kachaka_api.KachakaApiClient(kachaka_access_point)
                                if kachaka_access_point else kachaka_api.KachakaApiClient())
         self.robot_name = robot_name
@@ -152,6 +164,7 @@ class KachakaApiClientByZenoh:
         self.current_command_id = None
         self.is_async_command = False
         self.saw_running = False
+        self.retry_count = 0
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -369,6 +382,34 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
+    async def _handle_command_retry(self, error_code: int) -> bool:
+        """Handle retry logic for failed commands.
+
+        Args:
+            error_code: The error code from the failed command
+
+        Returns:
+            True if retry was initiated (caller should return early), False otherwise
+        """
+        if not self.retry_enabled or self.retry_count >= self.max_navigation_retries:
+            if self.retry_count >= self.max_navigation_retries:
+                self._log_error_msg(f'Max retries ({self.max_navigation_retries}) exceeded for command {self.task_id}')
+            return False
+
+        should_retry = await self._should_retry_command(error_code)
+        if not should_retry:
+            self._log_info(f'Error code {error_code} is not retriable')
+            return False
+
+        self.retry_count += 1
+        self._log_info(f'Retrying command (attempt {self.retry_count}/{self.max_navigation_retries})')
+
+        await asyncio.sleep(self.retry_interval)
+        if self.last_command:
+            self._execute_command(self.last_command)
+            return True
+        return False
+
     async def publish_result(self) -> None:
         """Publish command completion status to Zenoh.
 
@@ -454,8 +495,11 @@ class KachakaApiClientByZenoh:
 
                 if success:
                     self._log_info(f'Command {self.task_id} succeeded')
+                    self.retry_count = 0
                 else:
                     self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
+                    if await self._handle_command_retry(error_code):
+                        return  # Retry initiated, don't publish yet
 
             # Publish and reset
             self.last_command_result = result
@@ -468,6 +512,49 @@ class KachakaApiClientByZenoh:
             self._log_error('RPC', method_name, e)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
+
+    async def _should_retry_command(self, error_code: int) -> bool:
+        """Determine if a command should be retried based on its error code.
+
+        Args:
+            error_code (int): The error code from the failed command
+
+        Returns:
+            bool: True if the command should be retried, False otherwise
+        """
+        try:
+            # error_code=0 with success=False typically means the navigation was cancelled
+            # (e.g., due to temporary obstacles from LiDAR noise). This should be retried.
+            if error_code == 0:
+                self.logger.info('error_code=0 with failure - navigation may have been cancelled, will retry')
+                return True
+
+            # Get error code details from Kachaka API
+            error_code_dict = await self.run_method('get_robot_error_code')
+
+            if not isinstance(error_code_dict, dict):
+                self.logger.warning(f'Unexpected error code dict format: {error_code_dict}')
+                # If we can't get error details, allow retry
+                return True
+
+            # Look up the error code
+            error_info = error_code_dict.get(str(error_code))
+            if not error_info:
+                self.logger.warning(f'Error code {error_code} not found in error code dictionary')
+                # Unknown error code, allow retry
+                return True
+
+            # Get the error type
+            error_type = error_info.get('errorType', '')
+            self._log_info(f'Error code {error_code}: type={error_type}, title={error_info.get("title", "")}')
+
+            # Check if this error type should trigger a retry
+            return error_type in self.retry_on_error_types
+
+        except Exception as e:
+            self.logger.error(f'Error checking if command should retry: {str(e)}')
+            # On error, be conservative and allow retry
+            return True
 
     def _to_dict(
         self, response: Union[dict, list, RepeatedCompositeContainer,
@@ -593,6 +680,7 @@ class KachakaApiClientByZenoh:
             self.last_command = command
             self.last_command_result = None
             self.current_command_id = None
+            self.retry_count = 0
 
             # Execute the command
             if method_name == 'switch_map':
@@ -737,6 +825,7 @@ class KachakaApiClientByZenoh:
         for the next command.
         """
         self.task_id = None
+        self.retry_count = 0
         self.is_async_command = False
         self.saw_running = False
         self.current_command_id = None

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -78,19 +78,19 @@ class CommandCompletion:
 @dataclass(frozen=True)
 class MapState:
     telemetry_map_name: str
-    command_context_map_name: str
+    command_context_map_name: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not self.telemetry_map_name:
             raise ValueError('telemetry_map_name must not be empty')
-        if not self.command_context_map_name:
-            raise ValueError('command_context_map_name must not be empty')
 
     @classmethod
-    def initial(cls, map_name: str = 'L1') -> 'MapState':
-        return cls(telemetry_map_name=map_name, command_context_map_name=map_name)
+    def initial(cls) -> 'MapState':
+        return cls(telemetry_map_name='unknown', command_context_map_name=None)
 
     def with_telemetry_map_name(self, map_name: str) -> 'MapState':
+        if self.command_context_map_name is None:
+            return MapState(telemetry_map_name=map_name, command_context_map_name=map_name)
         return MapState(telemetry_map_name=map_name, command_context_map_name=self.command_context_map_name)
 
     def with_map_name(self, map_name: str) -> 'MapState':
@@ -792,7 +792,11 @@ class KachakaApiClientByZenoh:
                 elif method_name == 'move_to_pose':
                     args = command['args'].copy()
                     map_name = args.pop('map_name', None)
-                    if map_name is not None and map_name != self.map_state.command_context_map_name:
+                    if (
+                        map_name is not None
+                        and self.map_state.command_context_map_name is not None
+                        and map_name != self.map_state.command_context_map_name
+                    ):
                         # Map name mismatch indicates RMF has incorrect floor information.
                         # Reject the navigation command and return error to trigger replanning.
                         self._log_warning(

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -17,6 +17,7 @@
 
 import argparse
 import asyncio
+from dataclasses import dataclass
 import json
 import logging
 import os
@@ -33,6 +34,67 @@ import kachaka_api
 from kachaka_api.generated import kachaka_api_pb2 as pb2
 import yaml
 import zenoh
+
+
+@dataclass(frozen=True)
+class Pose:
+    x: float
+    y: float
+    theta: float
+
+    @classmethod
+    def zero(cls) -> 'Pose':
+        return cls(0.0, 0.0, 0.0)
+
+    def as_list(self) -> List[float]:
+        return [self.x, self.y, self.theta]
+
+
+@dataclass(frozen=True)
+class CommandCompletion:
+    task_id: str
+    is_completed: bool
+    success: Optional[bool]
+    error_code: Optional[int]
+
+    def __post_init__(self) -> None:
+        if not self.task_id:
+            raise ValueError('task_id must not be empty')
+        if not self.is_completed and (self.success is not None or self.error_code is not None):
+            raise ValueError('in-progress completion must not have success or error_code')
+
+    def as_payload(self) -> Dict[str, Any]:
+        """Return the payload for Zenoh publishing.
+
+        Only includes fields that consumers (fleet_adapter, lci_lift_request_converter) use.
+        success/error_code are internal state for retry logic and not published.
+        """
+        return {
+            'id': self.task_id,
+            'is_completed': self.is_completed,
+        }
+
+
+@dataclass(frozen=True)
+class MapState:
+    telemetry_map_name: str
+    command_context_map_name: str
+
+    def __post_init__(self) -> None:
+        if not self.telemetry_map_name:
+            raise ValueError('telemetry_map_name must not be empty')
+        if not self.command_context_map_name:
+            raise ValueError('command_context_map_name must not be empty')
+
+    @classmethod
+    def initial(cls, map_name: str = 'L1') -> 'MapState':
+        return cls(telemetry_map_name=map_name, command_context_map_name=map_name)
+
+    def with_telemetry_map_name(self, map_name: str) -> 'MapState':
+        return MapState(telemetry_map_name=map_name, command_context_map_name=self.command_context_map_name)
+
+    def with_map_name(self, map_name: str) -> 'MapState':
+        return MapState(telemetry_map_name=map_name, command_context_map_name=map_name)
 
 
 class KachakaApiClientByZenoh:
@@ -59,7 +121,7 @@ class KachakaApiClientByZenoh:
     robot_name: str
     task_id: Optional[str]
     last_command: Optional[Dict[str, Any]]
-    last_command_result: Optional[Dict[str, Any]]
+    last_command_result: Optional[CommandCompletion]
     last_command_id: Optional[str]
     current_command_id: Optional[str]
     is_async_command: bool
@@ -126,8 +188,11 @@ class KachakaApiClientByZenoh:
         self.max_navigation_retries = navigation_retry.get('max_retries', 3)
         self.retry_interval = navigation_retry.get('retry_interval', 2.0)
         self.retry_on_error_types = navigation_retry.get('retry_on_error_types', ['Error'])
-        self.kachaka_client = (kachaka_api.KachakaApiClient(kachaka_access_point)
-                               if kachaka_access_point else kachaka_api.KachakaApiClient())
+        self.kachaka_client = (
+            kachaka_api.KachakaApiClient(kachaka_access_point)
+            if kachaka_access_point
+            else kachaka_api.KachakaApiClient()
+        )
         self.robot_name = robot_name
         self.task_id = None
         logging.basicConfig(
@@ -144,11 +209,13 @@ class KachakaApiClientByZenoh:
         self.battery_pub = self.session.declare_publisher(f'robots/{self.robot_name}/battery')
         self.map_name_pub = self.session.declare_publisher(f'robots/{self.robot_name}/map_name')
         self.command_is_completed_pub = self.session.declare_publisher(
-            f'robots/{self.robot_name}/command_is_completed')
+            f'robots/{self.robot_name}/command_is_completed'
+        )
 
         # Initialize queryable for request-reply pattern
-        self.status_queryable = self.session.declare_queryable(f'robots/{self.robot_name}/status',
-                                                               self._status_query_handler)
+        self.status_queryable = self.session.declare_queryable(
+            f'robots/{self.robot_name}/status', self._status_query_handler
+        )
 
         # Initialize querier for fetching commands from fleet adapter
         self.command_querier = self.session.declare_querier(
@@ -158,9 +225,9 @@ class KachakaApiClientByZenoh:
         )
 
         self.logger.info(f'Initialized KachakaApiClientByZenoh for robot {robot_name}')
-        self.last_pose = [0.0, 0.0, 0.0]
+        self.last_pose = Pose.zero()
         self.last_battery = 100.0
-        self.map_name = 'L1'
+        self.map_state = MapState.initial()
         self.last_command = None
         self.last_command_result = None
         self.last_command_id = None
@@ -185,7 +252,7 @@ class KachakaApiClientByZenoh:
         conf.insert_json5('connect/endpoints', json.dumps([f'tcp/{zenoh_router}']))
         return conf
 
-    async def run_method(self, method_name: str, args: Dict[str, Any] = {}) -> Any:  # noqa: ANN401
+    async def run_method(self, method_name: str, args: Optional[Dict[str, Any]] = None) -> Any:  # noqa: ANN401
         """Run a KachakaApiClient method with the provided arguments.
 
         Args:
@@ -260,8 +327,9 @@ class KachakaApiClientByZenoh:
     def _get_command_state_response(self) -> Dict[str, Any]:
         """Fetch the latest command state including command_id."""
         try:
-            response = self.kachaka_client.stub.GetCommandState(pb2.GetRequest(),
-                                                                timeout=self.grpc_status_check_timeout)
+            response = self.kachaka_client.stub.GetCommandState(
+                pb2.GetRequest(), timeout=self.grpc_status_check_timeout
+            )
             return MessageToDict(response)
         except RpcError as e:
             self._log_error('RPC', 'get_command_state', e)
@@ -270,8 +338,9 @@ class KachakaApiClientByZenoh:
     def _get_last_command_result_response(self) -> Dict[str, Any]:
         """Fetch the most recent command result including command_id."""
         try:
-            response = self.kachaka_client.stub.GetLastCommandResult(pb2.GetRequest(),
-                                                                     timeout=self.grpc_status_check_timeout)
+            response = self.kachaka_client.stub.GetLastCommandResult(
+                pb2.GetRequest(), timeout=self.grpc_status_check_timeout
+            )
             return MessageToDict(response)
         except RpcError as e:
             self._log_error('RPC', 'get_last_command_result', e)
@@ -312,16 +381,16 @@ class KachakaApiClientByZenoh:
         method_name = 'publish_pose'
         try:
             response = self.kachaka_client.stub.GetRobotPose(pb2.GetRequest(), timeout=self.grpc_telemetry_timeout)
-            pose = [response.pose.x, response.pose.y, response.pose.theta]
+            pose = Pose(response.pose.x, response.pose.y, response.pose.theta)
             self.last_pose = pose
-            self._publish_to_zenoh(self.pose_pub, pose)
+            self._publish_to_zenoh(self.pose_pub, pose.as_list())
         except RpcError as e:
             if e.code() == StatusCode.DEADLINE_EXCEEDED:
                 self.logger.warning(f'Timeout in {method_name}, publishing cached value')
-                self._publish_to_zenoh(self.pose_pub, self.last_pose)
+                self._publish_to_zenoh(self.pose_pub, self.last_pose.as_list())
             else:
                 self._log_error('RPC', method_name, e)
-                self._publish_to_zenoh(self.pose_pub, self.last_pose)
+                self._publish_to_zenoh(self.pose_pub, self.last_pose.as_list())
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -356,16 +425,19 @@ class KachakaApiClientByZenoh:
         """
         method_name = 'publish_map_name'
         try:
-            map_list_response = self.kachaka_client.stub.GetMapList(pb2.GetRequest(),
-                                                                    timeout=self.grpc_telemetry_timeout)
-            map_id_response = self.kachaka_client.stub.GetCurrentMapId(pb2.GetRequest(),
-                                                                       timeout=self.grpc_telemetry_timeout)
+            map_list_response = self.kachaka_client.stub.GetMapList(
+                pb2.GetRequest(), timeout=self.grpc_telemetry_timeout
+            )
+            map_id_response = self.kachaka_client.stub.GetCurrentMapId(
+                pb2.GetRequest(), timeout=self.grpc_telemetry_timeout
+            )
 
             search_id = map_id_response.id
             kachaka_map_name = next(
-                (entry.name for entry in map_list_response.map_list_entries if entry.id == search_id), 'L1')
+                (entry.name for entry in map_list_response.map_list_entries if entry.id == search_id), 'L1'
+            )
             map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
-            self.map_name = map_name
+            self.map_state = self.map_state.with_telemetry_map_name(map_name)
 
             self._publish_to_zenoh(self.map_name_pub, map_name)
         except RpcError as e:
@@ -373,7 +445,7 @@ class KachakaApiClientByZenoh:
                 self.logger.warning(f'Timeout in {method_name}, publishing cached value')
             else:
                 self._log_error('RPC', method_name, e)
-            self._publish_to_zenoh(self.map_name_pub, self.map_name)
+            self._publish_to_zenoh(self.map_name_pub, self.map_state.telemetry_map_name)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -418,11 +490,7 @@ class KachakaApiClientByZenoh:
                     # Keep publishing last result for Pub/Sub reliability.
                     # Fleet adapter's ID check ensures stale completions are ignored.
                     if self.last_command_result:
-                        completion_payload = {
-                            'id': self.last_command_result['id'],
-                            'is_completed': self.last_command_result['is_completed'],
-                        }
-                        self._publish_to_zenoh(self.command_is_completed_pub, completion_payload)
+                        self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
                     return
 
                 state_res = self._get_command_state_response()
@@ -443,22 +511,29 @@ class KachakaApiClientByZenoh:
                             )
                             return
                     else:
-                        self.logger.debug('Command state missing commandId for task %s (state=%s)', self.task_id,
-                                          state_value)
+                        self.logger.debug(
+                            'Command state missing commandId for task %s (state=%s)', self.task_id, state_value
+                        )
 
                 if self._is_running_state(state_value):
                     self.saw_running = True
-                    result = {'id': self.task_id, 'is_completed': False, 'success': None, 'error_code': None}
+                    result = CommandCompletion(
+                        task_id=self.task_id,
+                        is_completed=False,
+                        success=None,
+                        error_code=None,
+                    )
                     self.last_command_result = result
-                    completion_payload = {'id': self.task_id, 'is_completed': False}
-                    self._publish_to_zenoh(self.command_is_completed_pub, completion_payload)
+                    self._publish_to_zenoh(self.command_is_completed_pub, result.as_payload())
                     return
 
                 if self.is_async_command and not self.saw_running:
                     if self.current_command_id is None and command_id and self._running_state_wait_expired():
                         self.current_command_id = command_id
-                        self._log_warning(f'RUNNING state was not observed within {self.running_state_wait}s; '
-                                          f'falling back to command_id={command_id} for task {self.task_id}')
+                        self._log_warning(
+                            f'RUNNING state was not observed within {self.running_state_wait}s; '
+                            f'falling back to command_id={command_id} for task {self.task_id}'
+                        )
                     elif self.current_command_id is None:
                         self.logger.debug('Async command: waiting to see RUNNING state first')
                         return
@@ -485,16 +560,21 @@ class KachakaApiClientByZenoh:
                 cmd_result = last_result.get('result')
                 if not isinstance(cmd_result, dict):
                     self._log_error_msg(f'Unexpected last command result format: {last_result}')
-                    result = {'id': self.task_id, 'is_completed': True, 'success': False, 'error_code': -1}
+                    result = CommandCompletion(
+                        task_id=self.task_id,
+                        is_completed=True,
+                        success=False,
+                        error_code=-1,
+                    )
                 else:
                     success = cmd_result.get('success', False)
                     error_code = cmd_result.get('errorCode', 0)
-                    result = {
-                        'id': self.task_id,
-                        'is_completed': True,
-                        'success': success,
-                        'error_code': error_code,
-                    }
+                    result = CommandCompletion(
+                        task_id=self.task_id,
+                        is_completed=True,
+                        success=success,
+                        error_code=error_code,
+                    )
 
                     if success:
                         self._log_info(f'Command {self.task_id} succeeded')
@@ -506,9 +586,7 @@ class KachakaApiClientByZenoh:
 
                 # Publish and reset
                 self.last_command_result = result
-                completion_payload = {'id': result['id'], 'is_completed': result['is_completed']}
-                if (self._publish_to_zenoh(self.command_is_completed_pub, completion_payload) and
-                        result['is_completed']):
+                if self._publish_to_zenoh(self.command_is_completed_pub, result.as_payload()) and result.is_completed:
                     self._reset_async_command_state()
 
         except RpcError as e:
@@ -517,7 +595,7 @@ class KachakaApiClientByZenoh:
             else:
                 self._log_error('RPC', method_name, e)
             if self.last_command_result:
-                self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
+                self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -565,8 +643,8 @@ class KachakaApiClientByZenoh:
             return True
 
     def _to_dict(
-        self, response: Union[dict, list, RepeatedCompositeContainer,
-                              object]) -> Union[dict, list, RepeatedCompositeContainer]:
+        self, response: Union[dict, list, RepeatedCompositeContainer, object]
+    ) -> Union[dict, list, RepeatedCompositeContainer]:
         """Convert a response object to a dictionary or list.
 
         Args:
@@ -590,10 +668,10 @@ class KachakaApiClientByZenoh:
         try:
             status_data = {
                 'robot_name': self.robot_name,
-                'pose': self.last_pose,
-                'map_name': self.map_name,
+                'pose': self.last_pose.as_list(),
+                'map_name': self.map_state.telemetry_map_name,
                 'battery': self.last_battery,
-                'command_is_completed': self.last_command_result if self.last_command_result else {},
+                'command_is_completed': self.last_command_result.as_payload() if self.last_command_result else {},
             }
             reply_value = json.dumps(status_data).encode()
             query.reply(query.key_expr, reply_value, encoding=zenoh.Encoding.APPLICATION_JSON)
@@ -633,8 +711,9 @@ class KachakaApiClientByZenoh:
                         else:
                             self.logger.debug(f'Skipping duplicate command ID: {command_id}')
                     else:
-                        error_payload = (reply.err.payload.to_string()
-                                         if reply.err and reply.err.payload else 'Unknown error')
+                        error_payload = (
+                            reply.err.payload.to_string() if reply.err and reply.err.payload else 'Unknown error'
+                        )
                         if error_payload == 'Timeout':
                             self.logger.debug('Query timeout (normal if no new commands)')
                         else:
@@ -646,9 +725,9 @@ class KachakaApiClientByZenoh:
             # Wait before next check
             await asyncio.sleep(self.command_check_interval)
 
-    def _prepare_async_command_args(self,
-                                    args: Dict[str, Any],
-                                    defaults: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def _prepare_async_command_args(
+        self, args: Dict[str, Any], defaults: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
         """Prepare arguments for async StartCommand methods.
 
         Sets wait_for_completion=False by default and updates is_async_command flag.
@@ -713,16 +792,18 @@ class KachakaApiClientByZenoh:
                 elif method_name == 'move_to_pose':
                     args = command['args'].copy()
                     map_name = args.pop('map_name', None)
-                    if map_name is not None and map_name != self.map_name:
+                    if map_name is not None and map_name != self.map_state.command_context_map_name:
                         # Map name mismatch indicates RMF has incorrect floor information.
                         # Reject the navigation command and return error to trigger replanning.
                         self._log_warning(
-                            f'Map name mismatch: requested={map_name}, current={self.map_name}. '
-                            f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
+                            f'Map name mismatch: requested={map_name}, '
+                            f'current={self.map_state.command_context_map_name}. '
+                            f'Rejecting navigation command to prevent navigation to wrong floor coordinates.'
+                        )
                         self._publish_command_completion(success=False, error_code=-2)
                         return
                     args = self._prepare_async_command_args(args, {'cancel_all': True})
-                    self.logger.debug(f'Current pose: {self.last_pose}')
+                    self.logger.debug(f'Current pose: {self.last_pose.as_list()}')
                     self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
                     response = self._execute_sync_method(method_name, args)
                     if self.is_async_command:
@@ -770,6 +851,7 @@ class KachakaApiClientByZenoh:
             # switch map only if the map is different from the current map id
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
+                self.map_state = self.map_state.with_map_name(args.get('map_name'))
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:
@@ -777,8 +859,12 @@ class KachakaApiClientByZenoh:
                 # Success/failure logging and notification handled by _execute_sync_method
                 # Update map_name immediately after successful switch_map
                 if response and isinstance(response, dict) and response.get('result', {}).get('success', False):
-                    self.map_name = args.get('map_name')
-                    self.logger.info(f'Updated self.map_name to {self.map_name} after successful switch_map')
+                    self.map_state = self.map_state.with_map_name(args.get('map_name'))
+                    self.logger.info(
+                        'Updated map state after successful switch_map: telemetry=%s command_context=%s',
+                        self.map_state.telemetry_map_name,
+                        self.map_state.command_context_map_name,
+                    )
         except RpcError as e:
             self._log_error('RPC', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
@@ -868,13 +954,16 @@ class KachakaApiClientByZenoh:
         if not self.task_id:
             return False
 
-        completion_result = {'id': self.task_id, 'is_completed': True, 'success': success, 'error_code': error_code}
+        completion_result = CommandCompletion(
+            task_id=self.task_id,
+            is_completed=True,
+            success=success,
+            error_code=error_code,
+        )
 
         self.last_command_result = completion_result
-        self.logger.debug(f'Publishing command completion: {completion_result}')
-        # Only publish id and is_completed to Zenoh; success/error_code are internal state
-        completion_payload = {'id': self.task_id, 'is_completed': True}
-        if not self._publish_to_zenoh(self.command_is_completed_pub, completion_payload):
+        self.logger.debug(f'Publishing command completion: {completion_result.as_payload()}')
+        if not self._publish_to_zenoh(self.command_is_completed_pub, completion_result.as_payload()):
             self._log_warning(f'Failed to publish completion for task {self.task_id}; keeping state for retry')
             return False
 
@@ -920,15 +1009,11 @@ class KachakaApiClientByZenoh:
                 retry_count += 1
                 last_error = e
                 self.logger.info('Send Dummy data')
-                self._publish_to_zenoh(self.pose_pub, self.last_pose)
+                self._publish_to_zenoh(self.pose_pub, self.last_pose.as_list())
                 self._publish_to_zenoh(self.battery_pub, self.last_battery)
-                self._publish_to_zenoh(self.map_name_pub, self.map_name)
+                self._publish_to_zenoh(self.map_name_pub, self.map_state.telemetry_map_name)
                 if self.last_command_result:
-                    completion_payload = {
-                        'id': self.last_command_result['id'],
-                        'is_completed': self.last_command_result['is_completed'],
-                    }
-                    self._publish_to_zenoh(self.command_is_completed_pub, completion_payload)
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
                 if e.code() == StatusCode.UNAVAILABLE:
                     self._log_error_msg(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
                     time.sleep(sleep_time)
@@ -938,7 +1023,8 @@ class KachakaApiClientByZenoh:
 
         error_details = last_error.details() if last_error else 'Unknown error'
         self._log_error_msg(
-            f'Failed to connect to gRPC server after {max_retries} attempts. Last error: {error_details}')
+            f'Failed to connect to gRPC server after {max_retries} attempts. Last error: {error_details}'
+        )
         return False
 
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -699,6 +699,7 @@ class KachakaApiClientByZenoh:
                     raise ValueError('Invalid command structure')
 
                 new_task_id = command.get('id', None)
+                is_retry = new_task_id is not None and new_task_id == self.task_id
                 self._complete_superseded_task(new_task_id)
                 method_name = command['method']
                 method_name = self.method_mapping.get(method_name, method_name)
@@ -714,7 +715,8 @@ class KachakaApiClientByZenoh:
                 self.is_async_command = False
                 self.saw_running = False
                 self.async_command_started_at = None
-                self.retry_count = 0
+                if not is_retry:
+                    self.retry_count = 0
 
                 # Execute the command
                 if method_name == 'switch_map':

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -114,6 +114,8 @@ class KachakaApiClientByZenoh:
         self.command_query_timeout = timeouts.get('command_query', 2.0)
         self.grpc_connection_sleep = timeouts.get('grpc_connection', 5)
         self.running_state_wait = timeouts.get('running_state_wait', 5.0)
+        self.grpc_telemetry_timeout = timeouts.get('grpc_telemetry', 5.0)
+        self.grpc_status_check_timeout = timeouts.get('grpc_status_check', 5.0)
         self.command_check_interval = intervals.get('command_check', 4.0)
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
@@ -258,7 +260,8 @@ class KachakaApiClientByZenoh:
     def _get_command_state_response(self) -> Dict[str, Any]:
         """Fetch the latest command state including command_id."""
         try:
-            response = self.kachaka_client.stub.GetCommandState(pb2.GetRequest())
+            response = self.kachaka_client.stub.GetCommandState(pb2.GetRequest(),
+                                                                timeout=self.grpc_status_check_timeout)
             return MessageToDict(response)
         except RpcError as e:
             self._log_error('RPC', 'get_command_state', e)
@@ -267,7 +270,8 @@ class KachakaApiClientByZenoh:
     def _get_last_command_result_response(self) -> Dict[str, Any]:
         """Fetch the most recent command result including command_id."""
         try:
-            response = self.kachaka_client.stub.GetLastCommandResult(pb2.GetRequest())
+            response = self.kachaka_client.stub.GetLastCommandResult(pb2.GetRequest(),
+                                                                     timeout=self.grpc_status_check_timeout)
             return MessageToDict(response)
         except RpcError as e:
             self._log_error('RPC', 'get_last_command_result', e)
@@ -301,93 +305,75 @@ class KachakaApiClientByZenoh:
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh.
 
-        Gets the robot's current pose from Kachaka API and publishes it to Zenoh.
-        The pose is formatted as a list [x, y, theta] where:
-        - x, y: position coordinates in meters
-        - theta: orientation in radians
-
-        Handles connection errors and unexpected response formats.
-
-        Raises:
-            Does not raise exceptions as they are caught and logged internally.
+        Gets the robot's current pose from Kachaka API via gRPC stub with timeout
+        and publishes it to Zenoh. On timeout, publishes cached value to keep
+        the telemetry loop running.
         """
         method_name = 'publish_pose'
         try:
-            pose_raw = await self.run_method('get_robot_pose')
-            try:
-                pose = [pose_raw['x'], pose_raw['y'], pose_raw['theta']]
-                self.last_pose = pose
-            except KeyError:
-                # Handle unexpected format or missing data appropriately
-                self._log_error_msg(f'{pose_raw} is unexpected response format')
-                return
-
+            response = self.kachaka_client.stub.GetRobotPose(pb2.GetRequest(), timeout=self.grpc_telemetry_timeout)
+            pose = [response.pose.x, response.pose.y, response.pose.theta]
+            self.last_pose = pose
             self._publish_to_zenoh(self.pose_pub, pose)
-        except ConnectionError as e:
-            self._log_error('Connection', method_name, e)
         except RpcError as e:
-            self._log_error('RPC', method_name, e)
+            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+                self.logger.warning(f'Timeout in {method_name}, publishing cached value')
+                self._publish_to_zenoh(self.pose_pub, self.last_pose)
+            else:
+                self._log_error('RPC', method_name, e)
+                self._publish_to_zenoh(self.pose_pub, self.last_pose)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
     async def publish_battery(self) -> None:
         """Publish the current robot battery to Zenoh.
 
-        Gets battery information from Kachaka API and publishes it to Zenoh.
-        Battery level is normalized to a 0.0-1.0 range from the original percentage.
-
-        Handles connection errors and unexpected response formats.
-
-        Raises:
-            Does not raise exceptions as they are caught and logged internally.
+        Gets battery information from Kachaka API via gRPC stub with timeout.
+        On timeout, publishes cached value to keep the telemetry loop running.
         """
         method_name = 'publish_battery'
         try:
-            res = await self.run_method('get_battery_info')
-            if isinstance(res, (list, tuple)) and len(res) > 0:
-                battery = res[0] / 100.0
-                self.last_battery = battery
-            else:
-                self._log_error_msg(f'Unexpected battery info format: {res}')
-                return
-
+            response = self.kachaka_client.stub.GetBatteryInfo(pb2.GetRequest(), timeout=self.grpc_telemetry_timeout)
+            battery = response.remaining_percentage / 100.0
+            self.last_battery = battery
             self._publish_to_zenoh(self.battery_pub, battery)
-        except ConnectionError as e:
-            self._log_error('Connection', method_name, e)
         except RpcError as e:
-            self._log_error('RPC', method_name, e)
+            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+                self.logger.warning(f'Timeout in {method_name}, publishing cached value')
+                self._publish_to_zenoh(self.battery_pub, self.last_battery)
+            else:
+                self._log_error('RPC', method_name, e)
+                self._publish_to_zenoh(self.battery_pub, self.last_battery)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
     async def publish_map_name(self) -> None:
         """Publish the current map name to Zenoh.
 
-        Gets the current map ID from Kachaka, looks up the map name
-        from the map list, applies any name mapping defined in the configuration,
-        and publishes the map name to Zenoh.
-
-        Uses the reverse_map_name_mapping to convert Kachaka's internal map names
-        (e.g., 'L27') to more descriptive names (e.g., '27F').
-
-        Handles connection errors and unexpected response formats.
-
-        Raises:
-            Does not raise exceptions as they are caught and logged internally.
+        Gets the current map ID from Kachaka via gRPC stub with timeout,
+        looks up the map name, applies name mapping, and publishes to Zenoh.
+        On timeout, publishes cached value to keep the telemetry loop running.
         """
         method_name = 'publish_map_name'
         try:
-            map_list = await self.run_method('get_map_list')
-            search_id = await self.run_method('get_current_map_id')
+            map_list_response = self.kachaka_client.stub.GetMapList(pb2.GetRequest(),
+                                                                    timeout=self.grpc_telemetry_timeout)
+            map_id_response = self.kachaka_client.stub.GetCurrentMapId(pb2.GetRequest(),
+                                                                       timeout=self.grpc_telemetry_timeout)
 
-            kachaka_map_name = next((item['name'] for item in map_list if item['id'] == search_id), 'L1')
+            search_id = map_id_response.id
+            kachaka_map_name = next(
+                (entry.name for entry in map_list_response.map_list_entries if entry.id == search_id), 'L1')
             map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
             self.map_name = map_name
 
             self._publish_to_zenoh(self.map_name_pub, map_name)
-        except ConnectionError as e:
-            self._log_error('Connection', method_name, e)
         except RpcError as e:
-            self._log_error('RPC', method_name, e)
+            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+                self.logger.warning(f'Timeout in {method_name}, publishing cached value')
+            else:
+                self._log_error('RPC', method_name, e)
+            self._publish_to_zenoh(self.map_name_pub, self.map_name)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -525,10 +511,13 @@ class KachakaApiClientByZenoh:
                         result['is_completed']):
                     self._reset_async_command_state()
 
-        except ConnectionError as e:
-            self._log_error('Connection', method_name, e)
         except RpcError as e:
-            self._log_error('RPC', method_name, e)
+            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+                self.logger.warning(f'Timeout in {method_name}, publishing cached value')
+            else:
+                self._log_error('RPC', method_name, e)
+            if self.last_command_result:
+                self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -1041,14 +1030,29 @@ def main() -> None:
             command_thread.start()
 
             while True:
-                try:
-                    asyncio.run(node.publish_pose())
-                    asyncio.run(node.publish_battery())
-                    asyncio.run(node.publish_map_name())
-                    asyncio.run(node.publish_result())
-                    consecutive_errors = 0  # Reset on success
-                except (ConnectionError, RpcError, Exception) as e:
-                    consecutive_errors = _handle_main_loop_error(node, e, consecutive_errors, max_consecutive_errors)
+                publish_fns = [
+                    node.publish_pose,
+                    node.publish_battery,
+                    node.publish_map_name,
+                    node.publish_result,
+                ]
+                any_success = False
+                for publish_fn in publish_fns:
+                    try:
+                        asyncio.run(publish_fn())
+                        any_success = True
+                    except Exception as e:
+                        node.logger.error(f'Error in {publish_fn.__name__}: {e}')
+
+                if any_success:
+                    consecutive_errors = 0
+                else:
+                    consecutive_errors += 1
+                    if consecutive_errors >= max_consecutive_errors:
+                        msg = f'Too many consecutive full failures ({consecutive_errors}), exiting'
+                        node.logger.error(msg)
+                        print(msg)
+                        raise RuntimeError(msg)
 
                 time.sleep(sleep_time)
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -432,7 +432,11 @@ class KachakaApiClientByZenoh:
                     # Keep publishing last result for Pub/Sub reliability.
                     # Fleet adapter's ID check ensures stale completions are ignored.
                     if self.last_command_result:
-                        self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
+                        completion_payload = {
+                            'id': self.last_command_result['id'],
+                            'is_completed': self.last_command_result['is_completed'],
+                        }
+                        self._publish_to_zenoh(self.command_is_completed_pub, completion_payload)
                     return
 
                 state_res = self._get_command_state_response()
@@ -460,15 +464,15 @@ class KachakaApiClientByZenoh:
                     self.saw_running = True
                     result = {'id': self.task_id, 'is_completed': False, 'success': None, 'error_code': None}
                     self.last_command_result = result
-                    self._publish_to_zenoh(self.command_is_completed_pub, result)
+                    completion_payload = {'id': self.task_id, 'is_completed': False}
+                    self._publish_to_zenoh(self.command_is_completed_pub, completion_payload)
                     return
 
                 if self.is_async_command and not self.saw_running:
                     if self.current_command_id is None and command_id and self._running_state_wait_expired():
                         self.current_command_id = command_id
-                        self._log_warning(
-                            f'RUNNING state was not observed within {self.running_state_wait}s; '
-                            f'falling back to command_id={command_id} for task {self.task_id}')
+                        self._log_warning(f'RUNNING state was not observed within {self.running_state_wait}s; '
+                                          f'falling back to command_id={command_id} for task {self.task_id}')
                     elif self.current_command_id is None:
                         self.logger.debug('Async command: waiting to see RUNNING state first')
                         return
@@ -516,7 +520,9 @@ class KachakaApiClientByZenoh:
 
                 # Publish and reset
                 self.last_command_result = result
-                if self._publish_to_zenoh(self.command_is_completed_pub, result) and result['is_completed']:
+                completion_payload = {'id': result['id'], 'is_completed': result['is_completed']}
+                if (self._publish_to_zenoh(self.command_is_completed_pub, completion_payload) and
+                        result['is_completed']):
                     self._reset_async_command_state()
 
         except ConnectionError as e:
@@ -874,7 +880,9 @@ class KachakaApiClientByZenoh:
 
         self.last_command_result = completion_result
         self.logger.debug(f'Publishing command completion: {completion_result}')
-        if not self._publish_to_zenoh(self.command_is_completed_pub, completion_result):
+        # Only publish id and is_completed to Zenoh; success/error_code are internal state
+        completion_payload = {'id': self.task_id, 'is_completed': True}
+        if not self._publish_to_zenoh(self.command_is_completed_pub, completion_payload):
             self._log_warning(f'Failed to publish completion for task {self.task_id}; keeping state for retry')
             return False
 
@@ -924,7 +932,11 @@ class KachakaApiClientByZenoh:
                 self._publish_to_zenoh(self.battery_pub, self.last_battery)
                 self._publish_to_zenoh(self.map_name_pub, self.map_name)
                 if self.last_command_result:
-                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
+                    completion_payload = {
+                        'id': self.last_command_result['id'],
+                        'is_completed': self.last_command_result['is_completed'],
+                    }
+                    self._publish_to_zenoh(self.command_is_completed_pub, completion_payload)
                 if e.code() == StatusCode.UNAVAILABLE:
                     self._log_error_msg(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
                     time.sleep(sleep_time)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -64,6 +64,7 @@ class KachakaApiClientByZenoh:
     current_command_id: Optional[str]
     is_async_command: bool
     saw_running: bool
+    async_command_started_at: Optional[float]
     command_check_interval: float
     logger: logging.Logger
     retry_enabled: bool
@@ -164,6 +165,7 @@ class KachakaApiClientByZenoh:
         self.current_command_id = None
         self.is_async_command = False
         self.saw_running = False
+        self.async_command_started_at = None
         self.retry_count = 0
         self._command_lock = threading.RLock()
 
@@ -289,6 +291,12 @@ class KachakaApiClientByZenoh:
             self.logger.debug(f'Captured command_id {command_id} for {method_name}')
         else:
             self.logger.warning(f'Async command {method_name} did not return commandId; awaiting state update')
+
+    def _running_state_wait_expired(self) -> bool:
+        """Return True when waiting for RUNNING has exceeded the configured timeout."""
+        if self.async_command_started_at is None:
+            return False
+        return (time.monotonic() - self.async_command_started_at) >= self.running_state_wait
 
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh.
@@ -456,8 +464,14 @@ class KachakaApiClientByZenoh:
                     return
 
                 if self.is_async_command and not self.saw_running:
-                    self.logger.debug('Async command: waiting to see RUNNING state first')
-                    return
+                    if self.current_command_id is None and command_id and self._running_state_wait_expired():
+                        self.current_command_id = command_id
+                        self._log_warning(
+                            f'RUNNING state was not observed within {self.running_state_wait}s; '
+                            f'falling back to command_id={command_id} for task {self.task_id}')
+                    elif self.current_command_id is None:
+                        self.logger.debug('Async command: waiting to see RUNNING state first')
+                        return
 
                 last_result = self._get_last_command_result_response()
                 self.logger.debug(f'GetLastCommandResult response: {last_result}')
@@ -661,6 +675,15 @@ class KachakaApiClientByZenoh:
         self.is_async_command = not prepared.get('wait_for_completion', True)
         return prepared
 
+    def _complete_superseded_task(self, new_task_id: Optional[str]) -> None:
+        """Mark the current active task as superseded before accepting a new one."""
+        if not self.task_id or self.task_id == new_task_id:
+            return
+
+        self._log_warning(f'Superseding active task {self.task_id} with new task {new_task_id}')
+        # error_code=-3: task was replaced by a newer command before completion.
+        self._publish_command_completion(success=False, error_code=-3)
+
     def _execute_command(self, command: Dict[str, Any]) -> None:
         """Unified command execution logic."""
         method_name = 'execute_command'
@@ -669,9 +692,11 @@ class KachakaApiClientByZenoh:
                 if not all(k in command for k in ('method', 'args')):
                     raise ValueError('Invalid command structure')
 
+                new_task_id = command.get('id', None)
+                self._complete_superseded_task(new_task_id)
                 method_name = command['method']
                 method_name = self.method_mapping.get(method_name, method_name)
-                self.task_id = command.get('id', None)
+                self.task_id = new_task_id
 
                 if not hasattr(self.kachaka_client, method_name):
                     raise AttributeError(f'Invalid method: {method_name}')
@@ -680,6 +705,9 @@ class KachakaApiClientByZenoh:
                 self.last_command = command
                 self.last_command_result = None
                 self.current_command_id = None
+                self.is_async_command = False
+                self.saw_running = False
+                self.async_command_started_at = None
                 self.retry_count = 0
 
                 # Execute the command
@@ -792,6 +820,7 @@ class KachakaApiClientByZenoh:
                 if self.is_async_command and success:
                     # Async command started, don't publish completion yet
                     # publish_result will handle completion after RUNNING state is seen
+                    self.async_command_started_at = time.monotonic()
                     self.logger.info(f'Async command {method_name} started')
                 elif success:
                     self.logger.info(f'Command {method_name} completed successfully')
@@ -829,8 +858,9 @@ class KachakaApiClientByZenoh:
         self.is_async_command = False
         self.saw_running = False
         self.current_command_id = None
+        self.async_command_started_at = None
 
-    def _publish_command_completion(self, success: bool, error_code: int) -> None:
+    def _publish_command_completion(self, success: bool, error_code: int) -> bool:
         """Publish command completion status to Zenoh.
 
         Args:
@@ -838,16 +868,19 @@ class KachakaApiClientByZenoh:
             error_code (int): The error code (0 if success)
         """
         if not self.task_id:
-            return
+            return False
 
         completion_result = {'id': self.task_id, 'is_completed': True, 'success': success, 'error_code': error_code}
 
         self.last_command_result = completion_result
         self.logger.debug(f'Publishing command completion: {completion_result}')
-        self._publish_to_zenoh(self.command_is_completed_pub, completion_result)
+        if not self._publish_to_zenoh(self.command_is_completed_pub, completion_result):
+            self._log_warning(f'Failed to publish completion for task {self.task_id}; keeping state for retry')
+            return False
 
         # Clear all async command tracking state after publishing
         self._reset_async_command_state()
+        return True
 
     def grpc_connection_check(self, max_retries: Optional[int] = None) -> bool:
         """Check if the gRPC connection to Kachaka API server is alive.

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -839,8 +839,9 @@ class KachakaApiClientByZenoh:
                     # Always publish failure immediately
                     self._publish_command_completion(success=False, error_code=error_code)
             else:
-                # No result field (e.g., query methods), assume success
+                # No result field (e.g., switch_map), assume success
                 self.logger.info(f'Command {method_name} executed successfully')
+                self._publish_command_completion(success=True, error_code=0)
 
             return response
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -78,7 +78,6 @@ class CommandCompletion:
 @dataclass(frozen=True)
 class MapState:
     telemetry_map_name: str
-    command_context_map_name: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not self.telemetry_map_name:
@@ -86,15 +85,10 @@ class MapState:
 
     @classmethod
     def initial(cls) -> 'MapState':
-        return cls(telemetry_map_name='unknown', command_context_map_name=None)
+        return cls(telemetry_map_name='unknown')
 
     def with_telemetry_map_name(self, map_name: str) -> 'MapState':
-        if self.command_context_map_name is None:
-            return MapState(telemetry_map_name=map_name, command_context_map_name=map_name)
-        return MapState(telemetry_map_name=map_name, command_context_map_name=self.command_context_map_name)
-
-    def with_map_name(self, map_name: str) -> 'MapState':
-        return MapState(telemetry_map_name=map_name, command_context_map_name=map_name)
+        return MapState(telemetry_map_name=map_name)
 
 
 class KachakaApiClientByZenoh:
@@ -228,6 +222,7 @@ class KachakaApiClientByZenoh:
         self.last_pose = Pose.zero()
         self.last_battery = 100.0
         self.map_state = MapState.initial()
+        self._command_context_map_name: Optional[str] = None
         self.last_command = None
         self.last_command_result = None
         self.last_command_id = None
@@ -438,6 +433,9 @@ class KachakaApiClientByZenoh:
             )
             map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
             self.map_state = self.map_state.with_telemetry_map_name(map_name)
+            with self._command_lock:
+                if self._command_context_map_name is None:
+                    self._command_context_map_name = map_name
 
             self._publish_to_zenoh(self.map_name_pub, map_name)
         except RpcError as e:
@@ -794,14 +792,14 @@ class KachakaApiClientByZenoh:
                     map_name = args.pop('map_name', None)
                     if (
                         map_name is not None
-                        and self.map_state.command_context_map_name is not None
-                        and map_name != self.map_state.command_context_map_name
+                        and self._command_context_map_name is not None
+                        and map_name != self._command_context_map_name
                     ):
                         # Map name mismatch indicates RMF has incorrect floor information.
                         # Reject the navigation command and return error to trigger replanning.
                         self._log_warning(
                             f'Map name mismatch: requested={map_name}, '
-                            f'current={self.map_state.command_context_map_name}. '
+                            f'current={self._command_context_map_name}. '
                             f'Rejecting navigation command to prevent navigation to wrong floor coordinates.'
                         )
                         self._publish_command_completion(success=False, error_code=-2)
@@ -855,19 +853,22 @@ class KachakaApiClientByZenoh:
             # switch map only if the map is different from the current map id
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
-                self.map_state = self.map_state.with_map_name(args.get('map_name'))
+                self._command_context_map_name = args.get('map_name')
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:
                 response = self._execute_sync_method('switch_map', payload)
-                # Success/failure logging and notification handled by _execute_sync_method
-                # Update map_name immediately after successful switch_map
-                if response and isinstance(response, dict) and response.get('result', {}).get('success', False):
-                    self.map_state = self.map_state.with_map_name(args.get('map_name'))
+                # Update command context if switch_map did not raise an exception.
+                # Note: switch_map response may lack 'result' field, so we check
+                # both formats: with result.success and without result (assume success).
+                success = True
+                if response and isinstance(response, dict) and 'result' in response:
+                    success = response['result'].get('success', False)
+                if success:
+                    self._command_context_map_name = args.get('map_name')
                     self.logger.info(
-                        'Updated map state after successful switch_map: telemetry=%s command_context=%s',
-                        self.map_state.telemetry_map_name,
-                        self.map_state.command_context_map_name,
+                        'Updated command_context_map_name after successful switch_map: %s',
+                        self._command_context_map_name,
                     )
         except RpcError as e:
             self._log_error('RPC', method_name, e)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -30,6 +30,7 @@ from google.protobuf.json_format import MessageToDict
 from grpc import RpcError
 from grpc import StatusCode
 import kachaka_api
+from kachaka_api.generated import kachaka_api_pb2 as pb2
 import yaml
 import zenoh
 
@@ -60,6 +61,9 @@ class KachakaApiClientByZenoh:
     last_command: Optional[Dict[str, Any]]
     last_command_result: Optional[Dict[str, Any]]
     last_command_id: Optional[str]
+    current_command_id: Optional[str]
+    is_async_command: bool
+    saw_running: bool
     command_check_interval: float
     logger: logging.Logger
 
@@ -102,6 +106,7 @@ class KachakaApiClientByZenoh:
 
         self.command_query_timeout = timeouts.get('command_query', 2.0)
         self.grpc_connection_sleep = timeouts.get('grpc_connection', 5)
+        self.running_state_wait = timeouts.get('running_state_wait', 5.0)
         self.command_check_interval = intervals.get('command_check', 4.0)
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
@@ -144,6 +149,9 @@ class KachakaApiClientByZenoh:
         self.last_command = None
         self.last_command_result = None
         self.last_command_id = None
+        self.current_command_id = None
+        self.is_async_command = False
+        self.saw_running = False
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -189,6 +197,21 @@ class KachakaApiClientByZenoh:
             self.logger.error(f'RPC error in {method_name}: {e.details()}')
             raise
 
+    def _log_info(self, message: str) -> None:
+        """Log info message and print to console."""
+        self.logger.info(message)
+        print(message)
+
+    def _log_warning(self, message: str) -> None:
+        """Log warning message and print to console."""
+        self.logger.warning(message)
+        print(message)
+
+    def _log_error_msg(self, message: str) -> None:
+        """Log error message and print to console."""
+        self.logger.error(message)
+        print(message)
+
     def _log_error(self, error_type: str, method_name: str, error: Exception) -> None:
         """Log an error with consistent formatting.
 
@@ -200,9 +223,7 @@ class KachakaApiClientByZenoh:
         error_msg = f'{error_type} error during {method_name}: {str(error)}'
         if isinstance(error, RpcError):
             error_msg = f'{error_type} error during {method_name}: {error.details()}'
-
-        self.logger.error(error_msg)
-        print(error_msg)
+        self._log_error_msg(error_msg)
 
     def _publish_to_zenoh(self, publisher: zenoh.Publisher, data: Union[Dict, List, str, int, float, bool]) -> bool:
         """Publish data to a Zenoh topic with consistent encoding.
@@ -214,10 +235,46 @@ class KachakaApiClientByZenoh:
         try:
             publisher.put(json.dumps(data).encode(), encoding=zenoh.Encoding.APPLICATION_JSON)
         except Exception as e:
-            self.logger.error(f'Failed to publish data to Zenoh: {str(e)}')
-            print(f'Failed to publish data to Zenoh: {str(e)}')
+            self._log_error_msg(f'Failed to publish data to Zenoh: {str(e)}')
             return False
         return True
+
+    def _get_command_state_response(self) -> Dict[str, Any]:
+        """Fetch the latest command state including command_id."""
+        try:
+            response = self.kachaka_client.stub.GetCommandState(pb2.GetRequest())
+            return MessageToDict(response)
+        except RpcError as e:
+            self._log_error('RPC', 'get_command_state', e)
+            raise
+
+    def _get_last_command_result_response(self) -> Dict[str, Any]:
+        """Fetch the most recent command result including command_id."""
+        try:
+            response = self.kachaka_client.stub.GetLastCommandResult(pb2.GetRequest())
+            return MessageToDict(response)
+        except RpcError as e:
+            self._log_error('RPC', 'get_last_command_result', e)
+            raise
+
+    def _is_running_state(self, state_value: Union[str, int, None]) -> bool:
+        """Return True if the provided state represents RUNNING."""
+        if isinstance(state_value, str):
+            return state_value.upper() == 'COMMAND_STATE_RUNNING'
+        if isinstance(state_value, int):
+            return state_value == pb2.CommandState.Value('COMMAND_STATE_RUNNING')
+        return False
+
+    def _update_current_command_id(self, response: Optional[Dict[str, Any]], method_name: str) -> None:
+        """Extract and store command_id for async commands if available."""
+        if not isinstance(response, dict):
+            return
+        command_id = response.get('commandId')
+        if command_id:
+            self.current_command_id = command_id
+            self.logger.debug(f'Captured command_id {command_id} for {method_name}')
+        else:
+            self.logger.warning(f'Async command {method_name} did not return commandId; awaiting state update')
 
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh.
@@ -240,8 +297,7 @@ class KachakaApiClientByZenoh:
                 self.last_pose = pose
             except KeyError:
                 # Handle unexpected format or missing data appropriately
-                self.logger.error(f'{pose_raw} is unexpected response format')
-                print(f'{pose_raw} is unexpected response format')
+                self._log_error_msg(f'{pose_raw} is unexpected response format')
                 return
 
             self._publish_to_zenoh(self.pose_pub, pose)
@@ -270,8 +326,7 @@ class KachakaApiClientByZenoh:
                 battery = res[0] / 100.0
                 self.last_battery = battery
             else:
-                self.logger.error(f'Unexpected battery info format: {res}')
-                print(f'Unexpected battery info format: {res}')
+                self._log_error_msg(f'Unexpected battery info format: {res}')
                 return
 
             self._publish_to_zenoh(self.battery_pub, battery)
@@ -315,48 +370,98 @@ class KachakaApiClientByZenoh:
             self._log_error('Unexpected', method_name, e)
 
     async def publish_result(self) -> None:
-        """Publish the last command completion status to Zenoh.
+        """Publish command completion status to Zenoh.
 
-        Checks the status of the most recently executed command and publishes
-        its completion status (true/false) to Zenoh along with the task ID.
-
-        Only publishes if there is an active task (task_id is set).
-        The task_id is set when a command is received via the Zenoh command topic.
-
-        The published result has the format:
-        {
-            "id": "<task_id>",
-            "is_completed": true/false
-        }
-
-        Handles connection errors and unexpected response formats.
-
-        Raises:
-            Does not raise exceptions as they are caught and logged internally.
+        Monitors active async commands and publishes their completion status.
+        Uses command_id to ensure state/result pairs belong to the active command.
         """
         method_name = 'publish_result'
         try:
             if not self.task_id:
-                # No active task to check
+                # Keep publishing last result for Pub/Sub reliability.
+                # Fleet adapter's ID check ensures stale completions are ignored.
+                if self.last_command_result:
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
                 return
 
-            res = await self.run_method('get_command_state')
-            result = {'id': self.task_id, 'is_completed': False}
+            if not self.grpc_connection_check():
+                raise ConnectionError('Failed to connect to Kachaka API server for publish_result')
 
-            if isinstance(res, (list, tuple)) and len(res) > 0 and isinstance(res[0], int):
-                result['is_completed'] = True if res[0] != 2 else False
+            state_res = self._get_command_state_response()
+            self.logger.debug(f'GetCommandState response: {state_res}')
+            command_id = state_res.get('commandId')
+            state_value = state_res.get('state')
+
+            if self.is_async_command:
+                if command_id:
+                    if self.current_command_id is None and self._is_running_state(state_value):
+                        self.current_command_id = command_id
+                        self.logger.debug(f'Bound command_id {command_id} to task {self.task_id}')
+                    elif self.current_command_id and command_id != self.current_command_id:
+                        self.logger.debug(
+                            'Ignoring command state for command_id %s (expecting %s)',
+                            command_id,
+                            self.current_command_id,
+                        )
+                        return
+                else:
+                    self.logger.debug('Command state missing commandId for task %s (state=%s)', self.task_id,
+                                      state_value)
+
+            if self._is_running_state(state_value):
+                self.saw_running = True
+                result = {'id': self.task_id, 'is_completed': False, 'success': None, 'error_code': None}
+                self.last_command_result = result
+                self._publish_to_zenoh(self.command_is_completed_pub, result)
+                return
+
+            if self.is_async_command and not self.saw_running:
+                self.logger.debug('Async command: waiting to see RUNNING state first')
+                return
+
+            last_result = self._get_last_command_result_response()
+            self.logger.debug(f'GetLastCommandResult response: {last_result}')
+            result_command_id = last_result.get('commandId')
+
+            if self.is_async_command:
+                if result_command_id:
+                    if self.current_command_id is None and self.saw_running:
+                        self.current_command_id = result_command_id
+                        self.logger.debug(f'Bound result command_id {result_command_id} to task {self.task_id}')
+                    elif self.current_command_id and result_command_id != self.current_command_id:
+                        self.logger.debug(
+                            'Ignoring result for command_id %s (expecting %s)',
+                            result_command_id,
+                            self.current_command_id,
+                        )
+                        return
+                else:
+                    self.logger.debug(f'Last command result missing commandId for task {self.task_id}')
+
+            cmd_result = last_result.get('result')
+            if not isinstance(cmd_result, dict):
+                self._log_error_msg(f'Unexpected last command result format: {last_result}')
+                result = {'id': self.task_id, 'is_completed': True, 'success': False, 'error_code': -1}
             else:
-                # Handle unexpected format or missing data appropriately
-                self.logger.error(f'Unexpected command state format: {res}')
-                print(f'Unexpected command state format: {res}')
-                return
+                success = cmd_result.get('success', False)
+                error_code = cmd_result.get('errorCode', 0)
+                result = {
+                    'id': self.task_id,
+                    'is_completed': True,
+                    'success': success,
+                    'error_code': error_code,
+                }
 
-            self.logger.debug(f'Command {self.task_id} completed: {result["is_completed"]}')
+                if success:
+                    self._log_info(f'Command {self.task_id} succeeded')
+                else:
+                    self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
+
+            # Publish and reset
             self.last_command_result = result
-            put_result = self._publish_to_zenoh(self.command_is_completed_pub, result)
-            # Reset task_id if the command is completed
-            if put_result and result['is_completed']:
-                self.task_id = None
+            if self._publish_to_zenoh(self.command_is_completed_pub, result) and result['is_completed']:
+                self._reset_async_command_state()
+
         except ConnectionError as e:
             self._log_error('Connection', method_name, e)
         except RpcError as e:
@@ -420,8 +525,7 @@ class KachakaApiClientByZenoh:
 
                         # Check if this is a new command
                         if command_id and command_id != self.last_command_id:
-                            self.logger.info(f'Received new command: {command}')
-                            print(f'New command: {command["method"]} (ID: {command_id})')
+                            self._log_info(f'New command: {command["method"]} (ID: {command_id})')
 
                             # Update last command ID to prevent duplicate processing
                             self.last_command_id = command_id
@@ -430,8 +534,7 @@ class KachakaApiClientByZenoh:
                             try:
                                 self._execute_command(command)
                             except Exception as e:
-                                self.logger.error(f'Error processing command: {str(e)}')
-                                print(f'Error processing command: {str(e)}')
+                                self._log_error_msg(f'Error processing command: {str(e)}')
                         else:
                             self.logger.debug(f'Skipping duplicate command ID: {command_id}')
                     else:
@@ -448,6 +551,30 @@ class KachakaApiClientByZenoh:
             # Wait before next check
             await asyncio.sleep(self.command_check_interval)
 
+    def _prepare_async_command_args(self,
+                                    args: Dict[str, Any],
+                                    defaults: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Prepare arguments for async StartCommand methods.
+
+        Sets wait_for_completion=False by default and updates is_async_command flag.
+
+        Args:
+            args: Original command arguments
+            defaults: Additional default values to set if not present
+
+        Returns:
+            Prepared arguments dict
+        """
+        prepared = args.copy() if args else {}
+        if defaults:
+            for key, value in defaults.items():
+                if key not in prepared:
+                    prepared[key] = value
+        if 'wait_for_completion' not in prepared:
+            prepared['wait_for_completion'] = False
+        self.is_async_command = not prepared.get('wait_for_completion', True)
+        return prepared
+
     def _execute_command(self, command: Dict[str, Any]) -> None:
         """Unified command execution logic."""
         method_name = 'execute_command'
@@ -462,32 +589,41 @@ class KachakaApiClientByZenoh:
             if not hasattr(self.kachaka_client, method_name):
                 raise AttributeError(f'Invalid method: {method_name}')
 
-            self.logger.info(f'Executing command: {method_name} (ID: {self.task_id})')
-            print(f'Executing: {method_name}')
+            self._log_info(f'Executing command: {method_name} (ID: {self.task_id})')
             self.last_command = command
             self.last_command_result = None
+            self.current_command_id = None
 
             # Execute the command
             if method_name == 'switch_map':
-                args = command['args']
-                self._execute_switch_map_sync(args)
+                self._execute_switch_map_sync(command['args'])
             elif method_name == 'move_to_pose':
-                args = command['args']
+                args = command['args'].copy()
                 map_name = args.pop('map_name', None)
                 if map_name is not None and map_name != self.map_name:
-                    self.logger.warning(f'Map name {map_name} does not match current map {self.map_name}')
+                    # Map name mismatch indicates RMF has incorrect floor information.
+                    # Reject the navigation command and return error to trigger replanning.
+                    self._log_warning(
+                        f'Map name mismatch: requested={map_name}, current={self.map_name}. '
+                        f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
+                    self._publish_command_completion(success=False, error_code=-2)
                     return
-                if 'cancel_all' not in args:
-                    args['cancel_all'] = True
-                if 'wait_for_completion' not in args:
-                    args['wait_for_completion'] = False
-                self.logger.debug(f'move_to_pose args: {args}')
-                self._execute_sync_method(method_name, args)
+                args = self._prepare_async_command_args(args, {'cancel_all': True})
+                self.logger.debug(f'Current pose: {self.last_pose}')
+                self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
+                response = self._execute_sync_method(method_name, args)
+                if self.is_async_command:
+                    self._update_current_command_id(response, method_name)
+            elif method_name == 'return_home':
+                args = self._prepare_async_command_args(command['args'])
+                response = self._execute_sync_method(method_name, args)
+                if self.is_async_command:
+                    self._update_current_command_id(response, method_name)
             else:
+                self.logger.debug(f'{method_name} args: {command["args"]}')
                 self._execute_sync_method(method_name, command['args'])
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
-            self.logger.error(f'Invalid command: {str(e)}')
-            print(f'Invalid command: {str(e)}')
+            self._log_error_msg(f'Invalid command: {str(e)}')
         except (ConnectionError, RpcError, Exception) as e:
             self._log_error('Unexpected', f'executing command {method_name}', e)
 
@@ -511,8 +647,8 @@ class KachakaApiClientByZenoh:
             map_id = next((item['id'] for item in map_list if item['name'] == map_name), None)
 
             if map_id is None:
-                self.logger.error(f'Map {map_name} not found')
-                print(f'Map {map_name} not found')
+                self._log_error_msg(f'Map {map_name} not found')
+                self._publish_command_completion(success=False, error_code=-1)
                 return
 
             current_map_id = self.kachaka_client.get_current_map_id()
@@ -522,37 +658,107 @@ class KachakaApiClientByZenoh:
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
                 self.logger.info('Nothing to do - already on target map')
+                self._publish_command_completion(success=True, error_code=0)
             else:
-                self._execute_sync_method('switch_map', payload)
-                self.logger.info(f'Switched to map {map_name}', payload['pose'])
+                response = self._execute_sync_method('switch_map', payload)
+                # Success/failure logging and notification handled by _execute_sync_method
+                # Update map_name immediately after successful switch_map
+                if response and isinstance(response, dict) and response.get('result', {}).get('success', False):
+                    self.map_name = args.get('map_name')
+                    self.logger.info(f'Updated self.map_name to {self.map_name} after successful switch_map')
         except RpcError as e:
             self._log_error('RPC', method_name, e)
+            self._publish_command_completion(success=False, error_code=-1)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
+            self._publish_command_completion(success=False, error_code=-1)
 
-    def _execute_sync_method(self, method_name: str, args: Dict[str, Any]) -> None:
-        """Execute a method synchronously without asyncio.run().
+    def _execute_sync_method(self, method_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a method synchronously and publish completion status.
 
         Args:
             method_name (str): The name of the method to execute
             args (Dict[str, Any]): The arguments for the method
+
+        Returns:
+            Dict[str, Any]: The response from the method
         """
         try:
             if not self.grpc_connection_check():
                 error_msg = f'Failed to connect to Kachaka API server for method {method_name}'
                 self.logger.error(error_msg)
+                if self.task_id:
+                    self._publish_command_completion(success=False, error_code=-1)
                 raise ConnectionError(error_msg)
 
             method = getattr(self.kachaka_client, method_name)
             response = self._to_dict(method(**args))
-            self.logger.info(f'Command {method_name} executed successfully')
+
+            # Check if response contains a 'result' field (synchronous commands return Result)
+            if isinstance(response, dict) and 'result' in response:
+                result = response['result']
+                success = result.get('success', False)
+                # Note: MessageToDict converts snake_case to camelCase
+                error_code = result.get('errorCode', 0)
+
+                if self.is_async_command and success:
+                    # Async command started, don't publish completion yet
+                    # publish_result will handle completion after RUNNING state is seen
+                    self.logger.info(f'Async command {method_name} started')
+                elif success:
+                    self.logger.info(f'Command {method_name} completed successfully')
+                    # Synchronous command completed successfully
+                    self._publish_command_completion(success=True, error_code=0)
+                else:
+                    self._log_warning(f'Command {method_name} failed with error_code={error_code}')
+                    # Always publish failure immediately
+                    self._publish_command_completion(success=False, error_code=error_code)
+            else:
+                # No result field (e.g., query methods), assume success
+                self.logger.info(f'Command {method_name} executed successfully')
+
             return response
+
         except RpcError as e:
             self.logger.error(f'RPC error in {method_name}: {e.details()}')
+            if self.task_id:
+                self._publish_command_completion(success=False, error_code=-1)
             raise
         except Exception as e:
             self.logger.error(f'Unexpected error in {method_name}: {str(e)}')
+            if self.task_id:
+                self._publish_command_completion(success=False, error_code=-1)
             raise
+
+    def _reset_async_command_state(self) -> None:
+        """Reset all async command tracking state.
+
+        Called after command completion (success or failure) to prepare
+        for the next command.
+        """
+        self.task_id = None
+        self.is_async_command = False
+        self.saw_running = False
+        self.current_command_id = None
+
+    def _publish_command_completion(self, success: bool, error_code: int) -> None:
+        """Publish command completion status to Zenoh.
+
+        Args:
+            success (bool): Whether the command succeeded
+            error_code (int): The error code (0 if success)
+        """
+        if not self.task_id:
+            return
+
+        completion_result = {'id': self.task_id, 'is_completed': True, 'success': success, 'error_code': error_code}
+
+        self.last_command_result = completion_result
+        self.logger.debug(f'Publishing command completion: {completion_result}')
+        self._publish_to_zenoh(self.command_is_completed_pub, completion_result)
+
+        # Clear all async command tracking state after publishing
+        self._reset_async_command_state()
 
     def grpc_connection_check(self, max_retries: Optional[int] = None) -> bool:
         """Check if the gRPC connection to Kachaka API server is alive.
@@ -586,8 +792,7 @@ class KachakaApiClientByZenoh:
             try:
                 self.kachaka_client.get_robot_pose()
                 if retry_count > 0:
-                    self.logger.info(f'gRPC connection restored after {retry_count} retries')
-                    print(f'gRPC connection restored after {retry_count} retries')
+                    self._log_info(f'gRPC connection restored after {retry_count} retries')
                 return True
             except RpcError as e:
                 retry_count += 1
@@ -596,19 +801,18 @@ class KachakaApiClientByZenoh:
                 self._publish_to_zenoh(self.pose_pub, self.last_pose)
                 self._publish_to_zenoh(self.battery_pub, self.last_battery)
                 self._publish_to_zenoh(self.map_name_pub, self.map_name)
+                if self.last_command_result:
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result)
                 if e.code() == StatusCode.UNAVAILABLE:
-                    self.logger.error(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
-                    print(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
+                    self._log_error_msg(f'gRPC connection error ({retry_count}/{max_retries}): {e.details()}')
                     time.sleep(sleep_time)
                 else:
-                    self.logger.error(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
-                    print(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
+                    self._log_error_msg(f'Unexpected gRPC error: {e.details()} (code: {e.code()})')
                     raise e
 
         error_details = last_error.details() if last_error else 'Unknown error'
-        self.logger.error(
+        self._log_error_msg(
             f'Failed to connect to gRPC server after {max_retries} attempts. Last error: {error_details}')
-        print(f'Failed to connect to gRPC server after {max_retries} attempts')
         return False
 
 
@@ -644,8 +848,9 @@ def _handle_main_loop_error(
         node.logger.error(f'Unexpected error in main loop: {str(error)}')
 
     if consecutive_errors >= max_consecutive_errors:
-        node.logger.error(f'Too many consecutive errors ({consecutive_errors}), exiting')
-        print(f'Too many consecutive errors ({consecutive_errors}), exiting')
+        msg = f'Too many consecutive errors ({consecutive_errors}), exiting'
+        node.logger.error(msg)
+        print(msg)
         raise error
 
     return consecutive_errors
@@ -683,8 +888,9 @@ def main() -> None:
 
         try:
             # Start the node with periodic command checking via Queryable pattern
-            print('Starting KachakaApiClientByZenoh with periodic command checking...')
-            node.logger.info('Starting KachakaApiClientByZenoh with periodic command checking...')
+            msg = 'Starting KachakaApiClientByZenoh with periodic command checking...'
+            node.logger.info(msg)
+            print(msg)
 
             consecutive_errors = 0
             max_consecutive_errors = node.max_consecutive_errors

--- a/test/test_kachaka_command.py
+++ b/test/test_kachaka_command.py
@@ -27,13 +27,10 @@ from typing import Any, Dict, Optional
 import zenoh
 
 
-def create_switch_map_command(robot_name: str,
-                              map_name: str,
-                              pose: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
+def create_switch_map_command(map_name: str, pose: Optional[Dict[str, float]] = None) -> Dict[str, Any]:
     """Create a switch_map command.
 
     Args:
-        robot_name: Name of the robot
         map_name: Name of the map to switch to
         pose: Optional pose with x, y, theta. Defaults to origin.
 
@@ -53,15 +50,10 @@ def create_switch_map_command(robot_name: str,
     }
 
 
-def create_move_to_pose_command(robot_name: str,
-                                x: float,
-                                y: float,
-                                yaw: float,
-                                map_name: Optional[str] = None) -> Dict[str, Any]:
+def create_move_to_pose_command(x: float, y: float, yaw: float, map_name: Optional[str] = None) -> Dict[str, Any]:
     """Create a move_to_pose command.
 
     Args:
-        robot_name: Name of the robot
         x: Target x coordinate
         y: Target y coordinate
         yaw: Target orientation in radians
@@ -78,11 +70,8 @@ def create_move_to_pose_command(robot_name: str,
     return {'id': f'test_move_to_pose_{int(time.time())}', 'method': 'move_to_pose', 'args': args}
 
 
-def create_dock_command(robot_name: str) -> Dict[str, Any]:
+def create_dock_command() -> Dict[str, Any]:
     """Create a dock command.
-
-    Args:
-        robot_name: Name of the robot
 
     Returns:
         Command dictionary
@@ -203,7 +192,7 @@ def main() -> None:
                 pose = {'x': float(sys.argv[5]), 'y': float(sys.argv[6]), 'theta': float(sys.argv[7])}
                 print(f'Using custom pose: {pose}')
 
-            command = create_switch_map_command(robot_name, map_name, pose)
+            command = create_switch_map_command(map_name, pose)
 
         elif command_type == 'move_to_pose':
             if len(sys.argv) < 7:
@@ -216,10 +205,10 @@ def main() -> None:
             yaw = float(sys.argv[6])
             map_name = sys.argv[7] if len(sys.argv) > 7 else None
 
-            command = create_move_to_pose_command(robot_name, x, y, yaw, map_name)
+            command = create_move_to_pose_command(x, y, yaw, map_name)
 
         elif command_type == 'dock':
-            command = create_dock_command(robot_name)
+            command = create_dock_command()
 
         else:
             print(f'❌ Unknown command: {command_type}')

--- a/test/test_kachaka_command.py
+++ b/test/test_kachaka_command.py
@@ -123,15 +123,10 @@ def publish_command_via_queryable(zenoh_router: str, robot_name: str, command: D
                 result = json.loads(sample.payload.to_string())
                 result_id = result.get('id', 'unknown')
                 is_completed = result.get('is_completed', False)
-                success = result.get('success')
-                error_code = result.get('error_code')
 
                 if result_id == command_id:
                     if is_completed:
-                        if success:
-                            print(f'✅ Command completed successfully! (id: {result_id})')
-                        else:
-                            print(f'❌ Command failed! (id: {result_id}, error_code: {error_code})')
+                        print(f'✅ Command completed! (id: {result_id})')
                     else:
                         print(f'⏳ Command in progress... (id: {result_id})')
                 else:


### PR DESCRIPTION
## 概要
- RUNNING を見逃した非同期コマンドでも完了判定へ進める fallback を追加
- completion publish 成功時のみ状態を reset するよう修正
- 新しいコマンドで上書きされた task を `error_code=-3` で明示完了するよう修正
- 既存の retry と thread safety の流れは維持

- fix #23 
---

## 設計概要

### スレッド構成

```mermaid
graph LR
    subgraph "Main Thread (1秒間隔ループ)"
        A1[publish_pose] --> A2[publish_battery]
        A2 --> A3[publish_map_name]
        A3 --> A4["publish_result<br/>⚡ RLock取得"]
    end

    subgraph "Daemon Thread (4秒間隔ポーリング)"
        B1["Zenoh Query<br/>robots/{name}/command"] --> B2{新規コマンド?}
        B2 -->|Yes| B3["_execute_command<br/>⚡ RLock取得"]
    end

    subgraph "外部"
        C1["Kachaka API<br/>(gRPC :26400)"]
        C2["Fleet Adapter<br/>(Zenoh)"]
    end

    A4 -.->|GetCommandState<br/>GetLastCommandResult| C1
    B3 -.->|move_to_pose<br/>return_home 等| C1
    A4 -.->|command_is_completed| C2
    C2 -.->|command query| B1
```

### RLock 排他制御

`_command_lock` (RLock) により `publish_result` と `_execute_command` が共有変数に同時アクセスすることを防ぐ。

保護対象: `task_id`, `current_command_id`, `is_async_command`, `saw_running`, `last_command_result`, `retry_count`

| 箇所 | ロック内の処理 |
|---|---|
| `_execute_command` | バリデーション → supersede → 変数リセット → gRPC実行 → (同期: 完了Publish / 非同期: command_id記録) |
| `publish_result` | task_idチェック → GetCommandState → command_id照合 → RUNNING判定 → GetLastCommandResult → 結果判定 → 完了Publish |

### publish_result の状態遷移

```mermaid
flowchart TD
    START(["publish_result 呼び出し"]) --> LOCK["RLock 取得"]
    LOCK --> CHK_TASK{"task_id == None?"}

    CHK_TASK -->|Yes| RESEND["前回結果を再Publish<br/>(Pub/Sub信頼性対策)"]
    RESEND --> RET1([return])

    CHK_TASK -->|"No (コマンド実行中)"| GET_STATE["GetCommandState<br/>(gRPC同期呼び出し)"]

    GET_STATE --> CHK_ID{"command_id<br/>一致?"}
    CHK_ID -->|不一致| IGN1(["ignore → return<br/>(別コマンドの状態)"])

    CHK_ID -->|"一致 or 未設定"| CHK_RUN{"state ==<br/>RUNNING?"}
    CHK_RUN -->|Yes| PUB_RUN["saw_running = True<br/>is_completed=false Publish"]
    PUB_RUN --> RET2([return])

    CHK_RUN -->|No| CHK_SAW{"saw_running<br/>== False?"}
    CHK_SAW -->|"Yes"| CHK_TO{"タイムアウト<br/>expired?"}
    CHK_TO -->|No| RET3(["return<br/>(次ループで再チェック)"])
    CHK_TO -->|Yes| FALLBACK["フォールバック:<br/>現在のcommand_idで続行"]
    FALLBACK --> GET_RES

    CHK_SAW -->|"No (RUNNING検出済み)"| GET_RES["GetLastCommandResult<br/>(gRPC同期呼び出し)"]

    GET_RES --> CHK_RID{"result の<br/>command_id 一致?"}
    CHK_RID -->|不一致| IGN2(["ignore → return"])
    CHK_RID -->|一致| CHK_OK{"success?"}

    CHK_OK -->|True| PUB_OK["✅ 成功<br/>is_completed=true Publish<br/>retry_count = 0"]
    CHK_OK -->|False| CHK_RETRY{"リトライ<br/>可能?"}
    CHK_RETRY -->|Yes| DO_RETRY["リトライ実行<br/>_execute_command 再呼出<br/>→ return"]
    CHK_RETRY -->|No| PUB_FAIL["❌ 失敗<br/>is_completed=true Publish"]

    PUB_OK --> RESET["_reset_async_command_state<br/>task_id=None 等クリア"]
    PUB_FAIL --> RESET

    style LOCK fill:#fff2cc,stroke:#d6b656,stroke-width:3
    style GET_STATE fill:#f8cecc,stroke:#b85450
    style GET_RES fill:#f8cecc,stroke:#b85450
    style PUB_RUN fill:#e1d5e7,stroke:#9673a6
    style PUB_OK fill:#d5e8d4,stroke:#82b366
    style PUB_FAIL fill:#f8cecc,stroke:#b85450
    style RESET fill:#d5e8d4,stroke:#82b366
    style FALLBACK fill:#fff2cc,stroke:#d6b656
    style DO_RETRY fill:#fff2cc,stroke:#d6b656
```

### command_id チェックの設計意図

kachaka API の `GetCommandState` / `GetLastCommandResult` は**最後に実行されたコマンド**の情報を返す。手動操作等で別コマンドが割り込むと返却される command_id が変わるため、**二重チェック**で誤検出を防止している:

1. **GetCommandState側**: RUNNING 検出時に command_id をバインド
2. **GetLastCommandResult側**: result 側の command_id も照合

### RUNNING 状態を待つ理由

gRPC start 直後、kachaka 側で RUNNING になるまでラグがある。その間に `GetLastCommandResult` を呼ぶと**前のコマンドの結果**を返すため、RUNNING を一度検出してから結果を見る。タイムアウト（`running_state_wait`秒）後はフォールバックで command_id を紐付ける。

### 既知の制約: 手動操作によるスタック

非同期コマンド実行中に kachaka アプリ等で手動ゴールを設定すると:
- `publish_result` の command_id チェックで毎ループ ignore → return
- **ロックはされない**（毎回取得→解放）が、Fleet Adapter に完了通知が届かない
- **救済**: Fleet Adapter が次のコマンドを送ると supersede 処理 (`error_code=-3`) でクリアされる

---

## 実機テスト手順

### 前提
- Wi-Fi `kachaka02-AP` に接続済み
- このブランチをローカルにcheckout済み

### 1. 既存ブリッジプロセスを停止
```bash
ssh kachaka@192.168.1.100
ps aux | grep connect_openrmf_by_zenoh
kill <PID>
exit
```

### 2. Zenoh ルーターを起動（ローカル）
```bash
docker run --rm -p 7447:7447 eclipse/zenoh:latest
```

### 3. ブリッジを起動（ローカル）
```bash
ZENOH_ROUTER_ACCESS_POINT=localhost:7447 \
KACHAKA_ACCESS_POINT=192.168.1.100:26400 \
ROBOT_NAME=kachaka1 \
python scripts/connect_openrmf_by_zenoh.py
```

### 4. テスト実行（別ターミナル）
```bash
# 同一フロアナビゲーション → ✅ Command completed successfully! が表示される
python test/test_kachaka_command.py localhost:7447 kachaka1 move_to_pose 1.0 2.0 0.0

# return_home（dock）→ ドックに戻り完了通知が返る
python test/test_kachaka_command.py localhost:7447 kachaka1 dock

# コマンド上書き（superseded）→ ターミナルAに ❌ error_code: -3、ターミナルBが成功
# ターミナルA: 遠い目的地を指定
python test/test_kachaka_command.py localhost:7447 kachaka1 move_to_pose 10.0 0.0 0.0
# 移動開始を確認後、ターミナルB: 別コマンドを送信
python test/test_kachaka_command.py localhost:7447 kachaka1 move_to_pose -1.0 0.0 0.0

# ナビゲーションリトライ → ブリッジログに Retrying navigation command が出る
# ロボットの進路に障害物を置いてから実行
python test/test_kachaka_command.py localhost:7447 kachaka1 move_to_pose 10.0 0.0 0.0
```

### 後片付け
テスト後、kachaka02 に SSH して元のブリッジプロセスを再起動してください。

## 補足
- #18 / #22 / #24 に含まれていた command completion 関連の論点を切り出した PR です。
- #25 -> #26 -> #27 の順でレビューをお願いします。stacked PR なので、下の PR ほど前提変更が少なく、論点が明確です。
   - #18/#22/#24 は論点が混ざってレビューしづらかったため、上記 3 本に分解して出し直しています。