### PR TITLE
fix: switch_map完了レース条件とリトライのtask_id競合対策

### DIFF
--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -854,19 +854,27 @@ class KachakaApiClientByZenoh:
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:
-                response = self._execute_sync_method('switch_map', payload)
-                # Update command context if switch_map did not raise an exception.
-                # Note: switch_map response may lack 'result' field, so we check
-                # both formats: with result.success and without result (assume success).
+                # Suppress automatic completion in _execute_sync_method so we can
+                # publish map_name to Zenoh *before* notifying RMF of completion.
+                # This prevents a race where RMF receives the completion, queries
+                # the robot's map_name (still the old floor), and issues a
+                # navigation command with stale floor coordinates.
+                response = self._execute_sync_method('switch_map', payload, publish_completion=False)
                 success = True
                 if response and isinstance(response, dict) and 'result' in response:
                     success = response['result'].get('success', False)
                 if success:
-                    self._command_context_map_name = args.get('map_name')
+                    rmf_map_name = args.get('map_name')
+                    self._command_context_map_name = rmf_map_name
+                    self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
+                    self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                     self.logger.info(
-                        'Updated command_context_map_name after successful switch_map: %s',
-                        self._command_context_map_name,
+                        'Published map_name=%s to Zenoh after successful switch_map',
+                        rmf_map_name,
                     )
+                    self._publish_command_completion(success=True, error_code=0)
+                else:
+                    self._publish_command_completion(success=False, error_code=-1)
         except RpcError as e:
             self._log_error('RPC', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
@@ -874,12 +882,20 @@ class KachakaApiClientByZenoh:
             self._log_error('Unexpected', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
 
-    def _execute_sync_method(self, method_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Execute a method synchronously and publish completion status.
+    def _execute_sync_method(
+        self,
+        method_name: str,
+        args: Dict[str, Any],
+        publish_completion: bool = True,
+    ) -> Dict[str, Any]:
+        """Execute a method synchronously and optionally publish completion status.
 
         Args:
             method_name (str): The name of the method to execute
             args (Dict[str, Any]): The arguments for the method
+            publish_completion (bool): Whether to automatically publish completion
+                status. Set to False when the caller needs to perform additional
+                state updates (e.g., publishing map_name) before notifying RMF.
 
         Returns:
             Dict[str, Any]: The response from the method
@@ -888,7 +904,7 @@ class KachakaApiClientByZenoh:
             if not self.grpc_connection_check():
                 error_msg = f'Failed to connect to Kachaka API server for method {method_name}'
                 self.logger.error(error_msg)
-                if self.task_id:
+                if self.task_id and publish_completion:
                     self._publish_command_completion(success=False, error_code=-1)
                 raise ConnectionError(error_msg)
 
@@ -909,16 +925,17 @@ class KachakaApiClientByZenoh:
                     self.logger.info(f'Async command {method_name} started')
                 elif success:
                     self.logger.info(f'Command {method_name} completed successfully')
-                    # Synchronous command completed successfully
-                    self._publish_command_completion(success=True, error_code=0)
+                    if publish_completion:
+                        self._publish_command_completion(success=True, error_code=0)
                 else:
                     self._log_warning(f'Command {method_name} failed with error_code={error_code}')
-                    # Always publish failure immediately
-                    self._publish_command_completion(success=False, error_code=error_code)
+                    if publish_completion:
+                        self._publish_command_completion(success=False, error_code=error_code)
             else:
                 # No result field (e.g., switch_map), assume success
                 self.logger.info(f'Command {method_name} executed successfully')
-                self._publish_command_completion(success=True, error_code=0)
+                if publish_completion:
+                    self._publish_command_completion(success=True, error_code=0)
 
             return response
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -439,33 +439,46 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
-    async def _handle_command_retry(self, error_code: int) -> bool:
+    async def _handle_command_retry(self, task_id: str, error_code: int) -> bool:
         """Handle retry logic for failed commands.
 
         Args:
+            task_id: The task ID that produced the failed result
             error_code: The error code from the failed command
 
         Returns:
             True if retry was initiated (caller should return early), False otherwise
         """
-        if not self.retry_enabled or self.retry_count >= self.max_navigation_retries:
-            if self.retry_count >= self.max_navigation_retries:
-                self._log_error_msg(f'Max retries ({self.max_navigation_retries}) exceeded for command {self.task_id}')
-            return False
-
         should_retry = await self._should_retry_command(error_code)
         if not should_retry:
             self._log_info(f'Error code {error_code} is not retriable')
             return False
 
-        self.retry_count += 1
-        self._log_info(f'Retrying command (attempt {self.retry_count}/{self.max_navigation_retries})')
+        with self._command_lock:
+            if self.task_id != task_id:
+                self.logger.debug('Skip retry for stale task %s (active task: %s)', task_id, self.task_id)
+                return False
+            if not self.retry_enabled or self.retry_count >= self.max_navigation_retries:
+                if self.retry_count >= self.max_navigation_retries:
+                    self._log_error_msg(f'Max retries ({self.max_navigation_retries}) exceeded for command {task_id}')
+                return False
+            if not self.last_command:
+                return False
+
+            self.retry_count += 1
+            retry_count = self.retry_count
+            command_to_retry = self.last_command.copy()
+
+        self._log_info(f'Retrying command (attempt {retry_count}/{self.max_navigation_retries})')
 
         await asyncio.sleep(self.retry_interval)
-        if self.last_command:
-            self._execute_command(self.last_command)
-            return True
-        return False
+        with self._command_lock:
+            if self.task_id != task_id:
+                self.logger.debug('Cancel retry for stale task %s (active task: %s)', task_id, self.task_id)
+                return False
+
+        self._execute_command(command_to_retry)
+        return True
 
     async def publish_result(self) -> None:
         """Publish command completion status to Zenoh.
@@ -474,6 +487,8 @@ class KachakaApiClientByZenoh:
         Uses command_id to ensure state/result pairs belong to the active command.
         """
         method_name = 'publish_result'
+        retry_task_id: Optional[str] = None
+        retry_error_code: Optional[int] = None
         try:
             with self._command_lock:
                 if not self.task_id:
@@ -574,8 +589,16 @@ class KachakaApiClientByZenoh:
                         self.retry_count = 0
                     else:
                         self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
-                        if await self._handle_command_retry(error_code):
-                            return  # Retry initiated, don't publish yet
+                        retry_task_id = self.task_id
+                        retry_error_code = error_code
+
+            if retry_task_id is not None and retry_error_code is not None:
+                if await self._handle_command_retry(retry_task_id, retry_error_code):
+                    return  # Retry initiated, don't publish yet
+
+            with self._command_lock:
+                if retry_task_id is not None and self.task_id != retry_task_id:
+                    return
 
                 # Publish and reset
                 self.last_command_result = result

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -873,7 +873,10 @@ class KachakaApiClientByZenoh:
             # switch map only if the map is different from the current map id
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
-                self._command_context_map_name = args.get('map_name')
+                rmf_map_name = args.get('map_name')
+                self._command_context_map_name = rmf_map_name
+                self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
+                self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:


### PR DESCRIPTION
## 背景

リフト受け渡し (例: 8F→10F) 後の最初のタスクが高頻度でキャンセルされ、リトライでは成功する事象を調査した結果、以下3つの競合条件を特定。

## 含まれる修正

### 1. `08b8d30` — switch_map 完了前に map_name を Zenoh へ publish

`_execute_sync_method` は `result` フィールドが無いレスポンス（`switch_map` の成功応答など）で即座に `_publish_command_completion` を呼んでいた。RMF はその完了通知を受けて直後に navigation コマンドを発行するが、その時点で Zenoh 上の `map_name` はまだ旧フロア → RMF が旧フロア座標系で `move_to_pose` を投げ、`_command_context_map_name` との mismatch でコマンドが reject される。

`_execute_sync_method` に `publish_completion` パラメータを追加し、`_execute_switch_map_sync` 側で「map_name を Zenoh publish → 完了通知」の順を制御するよう変更。

### 2. `01ac674` — リトライ判定を task_id でガード

`_handle_command_retry` は現在の `self.task_id`を暗黙に参照しつつ `await asyncio.sleep` を挟むため、sleep 中に別コマンドに切り替わると **古いタスクのリトライが現タスクに対して走る**可能性があった。さらに `publish_result` 内で `_command_lock` を保持したまま `await` していたのも潜在的デッドロック源。

- `_handle_command_retry(task_id, error_code)` へ変更し、ロック内で `self.task_id != task_id` を検査
- `asyncio.sleep` 後にも再チェック
- `publish_result` から retry 呼び出しをロック外に出し、戻り後に task_id を再検証してから publish

### 3. `02f691a` — switch_map が no-op のケースでも map_name を publish

`map_id == current_map_id` で gRPC を呼ばず即時完了する分岐は、`_command_context_map_name` は更新していたが Zenoh 上の `map_name` / `map_state` は更新していなかった。フロア情報の一貫性のため、実スイッチ時と同じ publish を行うよう統一。

## ベースブランチ

`future/command-completion-fixes` (PR #25) の上に乗せる前提。#25 マージ後に追従予定。

## 動作確認

OpenRMF不要。`test/test_kachaka_command.py` を Zenoh router 経由で叩いて確認できる。

### 前提
- Kachaka 実機 + 本リポジトリの bridge (`scripts/connect_openrmf_by_zenoh.py`) を起動
- 別端末から `python test/test_kachaka_command.py <zenoh_router> <robot_name> ...` でコマンド送信
- 別端末で `zenoh subscribe '<robot_name>/map_name'` 等で map state を観測

### `08b8d30` — switch_map 完了前に map_name が更新される
- [ ] **E1: 異フロア switch_map → 直後 move_to_pose**
  - 27F → 29F へ `switch_map 29F` を投げる
  - 完了通知を受信した時点で `<robot>/map_name` の値が `L29` (Kachaka 内部名) に更新済みであることを確認
  - 続けて 29F 座標系の `move_to_pose` を投げ、reject されずに RUNNING に入ることを確認
  - 期待: ログに `Published map_name to Zenoh before completion` 相当の順序が現れる

### `02f691a` — switch_map が no-op のケース
- [ ] **E2: 同フロア switch_map (no-op)**
  - 既に 27F に居る状態で `switch_map 27F` を投げる
  - gRPC 呼び出しが走らず即時完了することをログで確認 (`map_id == current_map_id` 分岐)
  - それでも `<robot>/map_name` / `<robot>/map_state` が publish され、値が想定どおりであることを確認
  - 期待: 実スイッチケースと同じ payload が Zenoh 上に出る

### `01ac674` — retry が task_id でガードされる
- [ ] **E3: 古いタスクの retry が新タスクに伝播しない**
  - 失敗しやすい目的地で `move_to_pose` を投げ、`navigation_retry.retry_interval` (config.yaml) の sleep 中に**別の** `move_to_pose` で上書きする
  - 上書き後、古いタスクの retry が新しい task_id に対して発火しないことをログで確認
    - 期待ログ: `Task ID changed during retry sleep` / `Retry skipped: task_id mismatch` 等の skip 系メッセージ
  - 新タスク自体は通常通り完走すること

### 統合シナリオ
- [ ] **E4: リフト受け渡し後の初回タスクが成功**
  - 8F → 10F（または現場で再現していたフロア組）の RMF タスクを実行
  - 従来高頻度でキャンセルされていた初回タスクが 1 回で成功することを 3 回連続で確認
  - 失敗しても retry で救済されるのではなく **初回成功** を見ること（本 PR の主目的）

### 回帰確認
- [ ] **R1: 通常の `move_to_pose` / `dock` / `return_home` が従来通り完了する**
- [ ] **R2: navigation_retry が機能するケース** (`error_code` が retriable な失敗) で従来通り retry が走る