### PR TITLE
fix: gRPC half-open 検知と persistent stuck からの自動復旧

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,7 @@ timeouts:
   running_state_wait: 5.0   # Max wait time for RUNNING state after command sent
   grpc_telemetry: 5.0       # Timeout for telemetry gRPC calls (get_robot_pose, etc.)
   grpc_status_check: 5.0    # Timeout for command status gRPC calls (GetCommandState, etc.)
+  grpc_stuck: 30.0          # Threshold (sec) for treating persistent Deadline Exceeded as a stuck channel
 
 intervals:
   command_check: 4.0        # How often to check for new commands

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -22,7 +22,7 @@ if ! nc -z -w $timeout $KACHAKA_IP $SSH_PORT; then
     echo "See https://github.com/pf-robotics/kachaka-api?tab=readme-ov-file#playground%E3%81%ABssh%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B"
     exit 1
 fi
-RUN_LINE="jupyter-lab --port=26501 --ip='0.0.0.0' & uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502"
+RUN_ZENOH=""
 # Ask whether to set up Zenoh client. If yes, ask the router access point and the robot name.
 read -p "Do you want to set up the Zenoh client? (y/n) " -n 1 -r
 echo
@@ -31,9 +31,12 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
   read -p "Enter the robot name: " ROBOT_NAME
   read -p "Enter log level (DEBUG/INFO/WARNING/ERROR/CRITICAL) [INFO]: " LOG_LEVEL
   LOG_LEVEL=${LOG_LEVEL:-INFO}
-  RUN_LINE="$RUN_LINE & python3 sbgisen/connect_openrmf_by_zenoh.py"
+  RUN_ZENOH=1
 fi
-# Create the server setup script with dynamic KACHAKA_IP
+# Create the server setup script with dynamic KACHAKA_IP.
+# REST API (uvicorn) is launched by default; set DISABLE_REST_API=1 in the
+# Kachaka environment to skip it (useful for OpenRMF-only deployments and
+# for diagnosing gRPC server load issues).
 cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
@@ -46,7 +49,12 @@ export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export LOG_LEVEL=$LOG_LEVEL
 export PATH=/home/kachaka/.local/bin:\$PATH
-$RUN_LINE
+jupyter-lab --port=26501 --ip='0.0.0.0' &
+if [ "\${DISABLE_REST_API:-0}" != "1" ]; then
+  uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502 &
+fi
+${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
+wait
 EOF
 
 ssh -p $SSH_PORT kachaka@$KACHAKA_IP <<EOF

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -41,10 +41,6 @@ cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
 export KACHAKA_IP=$KACHAKA_IP
-# When running on the Kachaka robot internally, KACHAKA_ACCESS_POINT is optional
-if [ -n "$KACHAKA_IP" ]; then
-  export KACHAKA_ACCESS_POINT=\$KACHAKA_IP:26400
-fi
 export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export LOG_LEVEL=$LOG_LEVEL

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -56,7 +56,9 @@ fi
 ${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
 # Exit when any child process dies so the supervisor can restart the whole stack
 # (matches the original foreground-bridge behaviour where bridge death exited the script).
-trap 'kill 0' EXIT
+# Use jobs -p to limit the cleanup to processes this script started; kill 0 would
+# also signal the parent shell or unrelated members of the same process group.
+trap 'jobs -p | xargs -r kill 2>/dev/null' EXIT
 wait -n
 EOF
 

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -54,7 +54,10 @@ if [ "\${DISABLE_REST_API:-0}" != "1" ]; then
   uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502 &
 fi
 ${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
-wait
+# Exit when any child process dies so the supervisor can restart the whole stack
+# (matches the original foreground-bridge behaviour where bridge death exited the script).
+trap 'kill 0' EXIT
+wait -n
 EOF
 
 ssh -p $SSH_PORT kachaka@$KACHAKA_IP <<EOF

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -30,8 +30,8 @@ from google._upb._message import RepeatedCompositeContainer
 from google.protobuf.json_format import MessageToDict
 from grpc import RpcError
 from grpc import StatusCode
-import kachaka_api
 from kachaka_api.generated import kachaka_api_pb2 as pb2
+from kachaka_client_with_keepalive import KachakaApiClientWithKeepalive
 import yaml
 import zenoh
 
@@ -52,6 +52,18 @@ class Pose:
 
 @dataclass(frozen=True)
 class CommandCompletion:
+    """Internal command completion state.
+
+    error_code values used internally:
+        0   : success
+        -1  : unknown / format error
+        -2  : map name mismatch
+        -3  : superseded by a new command
+        -4  : gRPC channel persistently stuck (Deadline Exceeded > grpc_stuck threshold)
+
+    Negative error_codes are internal signals to RMF for replan; not retriable on Kachaka side.
+    """
+
     task_id: str
     is_completed: bool
     success: Optional[bool]
@@ -172,6 +184,7 @@ class KachakaApiClientByZenoh:
         self.running_state_wait = timeouts.get('running_state_wait', 5.0)
         self.grpc_telemetry_timeout = timeouts.get('grpc_telemetry', 5.0)
         self.grpc_status_check_timeout = timeouts.get('grpc_status_check', 5.0)
+        self.grpc_stuck_threshold = float(timeouts.get('grpc_stuck', 30.0))
         self.command_check_interval = intervals.get('command_check', 4.0)
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
@@ -182,8 +195,9 @@ class KachakaApiClientByZenoh:
         self.max_navigation_retries = navigation_retry.get('max_retries', 3)
         self.retry_interval = navigation_retry.get('retry_interval', 2.0)
         self.retry_on_error_types = navigation_retry.get('retry_on_error_types', ['Error'])
-        self.kachaka_client = (kachaka_api.KachakaApiClient(kachaka_access_point)
-                               if kachaka_access_point else kachaka_api.KachakaApiClient())
+        self.kachaka_access_point = kachaka_access_point
+        self.kachaka_client = (KachakaApiClientWithKeepalive(kachaka_access_point)
+                               if kachaka_access_point else KachakaApiClientWithKeepalive())
         self.robot_name = robot_name
         self.task_id = None
         logging.basicConfig(
@@ -227,6 +241,8 @@ class KachakaApiClientByZenoh:
         self.async_command_started_at = None
         self.retry_count = 0
         self._command_lock = threading.RLock()
+        self._client_lock = threading.RLock()
+        self._first_grpc_failure_time: Optional[float] = None
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -487,6 +503,7 @@ class KachakaApiClientByZenoh:
                     return
 
                 state_res = self._get_command_state_response()
+                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
@@ -583,12 +600,47 @@ class KachakaApiClientByZenoh:
                     self._reset_async_command_state()
 
         except RpcError as e:
-            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+            code = e.code()
+            is_deadline = code == StatusCode.DEADLINE_EXCEEDED
+            is_unavailable = code == StatusCode.UNAVAILABLE
+            if is_deadline:
                 self.logger.warning(f'Timeout in {method_name}, publishing cached value')
+            elif is_unavailable:
+                self.logger.warning(f'UNAVAILABLE in {method_name}, will reconstruct client')
             else:
                 self._log_error('RPC', method_name, e)
-            if self.last_command_result:
-                self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+
+            fail_recovery_needed = False
+            immediate_reconnect_needed = False
+            with self._command_lock:
+                if is_unavailable:
+                    immediate_reconnect_needed = True
+                    self._first_grpc_failure_time = None
+                elif is_deadline and self.task_id:
+                    now = time.monotonic()
+                    if self._first_grpc_failure_time is None:
+                        self._first_grpc_failure_time = now
+                    elif now - self._first_grpc_failure_time >= self.grpc_stuck_threshold:
+                        stuck_task = self.task_id
+                        self._log_error_msg(f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
+                                            f'publishing failure (error_code=-4) and reconstructing client')
+                        fail_result = CommandCompletion(
+                            task_id=stuck_task,
+                            is_completed=True,
+                            success=False,
+                            error_code=-4,
+                        )
+                        self.last_command_result = fail_result
+                        self._publish_to_zenoh(self.command_is_completed_pub, fail_result.as_payload())
+                        self._reset_async_command_state()
+                        self._first_grpc_failure_time = None
+                        fail_recovery_needed = True
+
+                if not (fail_recovery_needed or immediate_reconnect_needed) and self.last_command_result:
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+
+            if fail_recovery_needed or immediate_reconnect_needed:
+                self._reconstruct_kachaka_client()
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -601,6 +653,10 @@ class KachakaApiClientByZenoh:
         Returns:
             bool: True if the command should be retried, False otherwise
         """
+        # Negative error codes are internal signals to RMF (replan); never retry on Kachaka side.
+        if error_code < 0:
+            self.logger.info(f'Internal error code {error_code}; not retriable on Kachaka side')
+            return False
         try:
             # error_code=0 with success=False typically means the navigation was cancelled
             # (e.g., due to temporary obstacles from LiDAR noise). This should be retried.
@@ -945,6 +1001,31 @@ class KachakaApiClientByZenoh:
         self.saw_running = False
         self.current_command_id = None
         self.async_command_started_at = None
+
+    def _reconstruct_kachaka_client(self) -> bool:
+        """Recreate the KachakaApiClient to recover from a dead gRPC channel.
+
+        Closes the old channel explicitly before creating a new one to
+        release resources promptly. In-flight RPCs hold the old client
+        through their local references, so swapping the attribute is safe.
+        """
+        with self._client_lock:
+            old_client = self.kachaka_client
+            try:
+                self._log_info('Reconstructing KachakaApiClient to recover gRPC channel')
+                new_client = (KachakaApiClientWithKeepalive(self.kachaka_access_point)
+                              if self.kachaka_access_point else KachakaApiClientWithKeepalive())
+                self.kachaka_client = new_client
+                self._log_info('KachakaApiClient reconstructed successfully')
+                try:
+                    if hasattr(old_client, 'close'):
+                        old_client.close()
+                except Exception as ce:
+                    self.logger.warning(f'Failed to close old client channel: {ce}')
+                return True
+            except Exception as e:
+                self._log_error('Unexpected', '_reconstruct_kachaka_client', e)
+                return False
 
     def _publish_command_completion(self, success: bool, error_code: int) -> bool:
         """Publish command completion status to Zenoh.

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -54,14 +54,17 @@ class Pose:
 class CommandCompletion:
     """Internal command completion state.
 
-    error_code values used internally:
+    success and error_code are kept on the instance for the Kachaka-side retry
+    logic but are NOT published over Zenoh — see as_payload(). The signal that
+    actually reaches RMF is is_completed; flipping it to True for an active
+    task is what unblocks RMF from a stuck-running state.
+
+    error_code values used internally (not transmitted):
         0   : success
         -1  : unknown / format error
         -2  : map name mismatch
         -3  : superseded by a new command
         -4  : gRPC channel persistently stuck (Deadline Exceeded > grpc_stuck threshold)
-
-    Negative error_codes are internal signals to RMF for replan; not retriable on Kachaka side.
     """
 
     task_id: str
@@ -503,7 +506,6 @@ class KachakaApiClientByZenoh:
                     return
 
                 state_res = self._get_command_state_response()
-                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
@@ -549,6 +551,8 @@ class KachakaApiClientByZenoh:
                         return
 
                 last_result = self._get_last_command_result_response()
+                # Both GetCommandState and GetLastCommandResult succeeded; reset stuck timer.
+                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetLastCommandResult response: {last_result}')
                 result_command_id = last_result.get('commandId')
 
@@ -622,8 +626,12 @@ class KachakaApiClientByZenoh:
                         self._first_grpc_failure_time = now
                     elif now - self._first_grpc_failure_time >= self.grpc_stuck_threshold:
                         stuck_task = self.task_id
-                        self._log_error_msg(f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
-                                            f'publishing failure (error_code=-4) and reconstructing client')
+                        self._log_error_msg(
+                            f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
+                            f'publishing is_completed=True (internal error_code=-4) and reconstructing client')
+                        # error_code=-4 is internal-only; CommandCompletion.as_payload() drops it.
+                        # The signal that reaches RMF is is_completed=True, which unblocks the
+                        # adapter from treating the task as still running.
                         fail_result = CommandCompletion(
                             task_id=stuck_task,
                             is_completed=True,

--- a/scripts/kachaka_client_with_keepalive.py
+++ b/scripts/kachaka_client_with_keepalive.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env pipenv-shebang
+# -*- encoding: utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import grpc
+import kachaka_api
+from kachaka_api.base import _resolve_target
+from kachaka_api.base import ShelfLocationResolver
+from kachaka_api.generated.kachaka_api_pb2_grpc import KachakaApiStub
+
+
+class KachakaApiClientWithKeepalive(kachaka_api.KachakaApiClient):
+    """KachakaApiClient with HTTP/2 keepalive enabled for half-open detection.
+
+    The upstream library opens an unconfigured grpc.insecure_channel, leaving
+    no protocol-level liveness check. A persistently unresponsive server then
+    keeps producing DEADLINE_EXCEEDED rather than UNAVAILABLE because the
+    client never realizes the channel is dead.
+
+    This subclass replaces parent initialization to own the channel directly,
+    enabling explicit close during reconstruction and HTTP/2 PINGs that mark
+    the channel BROKEN within keepalive_timeout_ms when ACKs stop arriving.
+    """
+
+    KEEPALIVE_OPTIONS = [
+        ('grpc.keepalive_time_ms', 30000),
+        ('grpc.keepalive_timeout_ms', 10000),
+        ('grpc.keepalive_permit_without_calls', 1),
+        ('grpc.http2.max_pings_without_data', 0),
+    ]
+
+    def __init__(self, target: str = '100.94.1.1:26400') -> None:
+        target_resolved = _resolve_target(target)
+        if target_resolved is None:
+            raise ValueError(f'Invalid target: {target}')
+        self._channel = grpc.insecure_channel(target_resolved, options=self.KEEPALIVE_OPTIONS)
+        self.stub = KachakaApiStub(self._channel)
+        self.resolver = ShelfLocationResolver()
+
+    def close(self) -> None:
+        """Close the underlying gRPC channel. Idempotent."""
+        try:
+            self._channel.close()
+        except Exception:
+            pass

--- a/scripts/rest_kachaka_api.py
+++ b/scripts/rest_kachaka_api.py
@@ -41,7 +41,7 @@ async def init_channel() -> None:
     """
     global kachaka_client
     kachaka_client = kachaka_api.aio.KachakaApiClient(
-        os.getenv("KACHAKA_ACCESS_POINT", "localhost:26400"))
+        os.getenv("KACHAKA_ACCESS_POINT", "100.94.1.1:26400"))
     await kachaka_client.update_resolver()
 
 

--- a/test/test_kachaka_client_with_keepalive.py
+++ b/test/test_kachaka_client_with_keepalive.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for KachakaApiClientWithKeepalive."""
+
+from pathlib import Path
+import sys
+
+import grpc
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+
+from kachaka_client_with_keepalive import KachakaApiClientWithKeepalive  # noqa: E402
+
+
+def test_keepalive_options_present() -> None:
+    """KEEPALIVE_OPTIONS includes the expected gRPC channel arguments."""
+    keys = {opt[0] for opt in KachakaApiClientWithKeepalive.KEEPALIVE_OPTIONS}
+    assert 'grpc.keepalive_time_ms' in keys
+    assert 'grpc.keepalive_timeout_ms' in keys
+    assert 'grpc.keepalive_permit_without_calls' in keys
+
+
+def test_init_creates_channel_and_stub() -> None:
+    """Constructor builds a channel that can be closed without errors."""
+    client = KachakaApiClientWithKeepalive('127.0.0.1:1')
+    channel = client._channel  # noqa: SLF001
+    assert channel is not None
+    assert isinstance(channel, grpc.Channel)
+    assert client.stub is not None
+    client.close()
+
+
+def test_close_is_idempotent() -> None:
+    """close() can be called multiple times without raising."""
+    client = KachakaApiClientWithKeepalive('127.0.0.1:1')
+    client.close()
+    client.close()
+
+
+def test_invalid_target_raises() -> None:
+    """An unresolvable target string surfaces as ValueError."""
+    with pytest.raises(ValueError):
+        KachakaApiClientWithKeepalive('not-a-valid-target-string')


### PR DESCRIPTION
## 背景

`shintoda_rmf_demos` issue #27 のコメント (4311927217, 2026-04-24) で報告された 2026-04-20 14:34 の事象。

3系統ログのクロス突合により、12F navigation 中に Kachaka 側 gRPC が応答停止し以下を確認:

- 14:34:11 `move_to_pose` 実行開始、14:34:33 まで `RUNNING` 観測
- 14:34:34 ロボット位置 `(24.75, -38.43)` で固着 (12.88m 残)
- 14:34:39〜 `publish_pose/battery/map_name` すべて `Deadline Exceeded` → cached publish
- 14:34:54〜14:40:09 (5分35秒) `get_command_state` が永続 `Deadline Exceeded`
- この間 RMF 側に lost/replan/error 一切なし
- 14:48:18 結局プロセス再起動でようやく復旧

PR #30 の switch_map race 修正では捕まらない別事象。

## 想定根本原因

1. **HTTP/2 アプリ層の half-open**: kachaka-api が `grpc.insecure_channel()` を options 無しで張っているため keepalive PING が無く、client から見ると channel が生きていることになっている (本 PR の Toxiproxy 検証で確認済み、本家 kachaka-api には未報告)
2. **エラー経路の盲点**: `publish_result` が `Deadline Exceeded` 受信時にキャッシュ済み RUNNING を再 publish するだけで、RMF に詰まりが伝わらない
3. **rest_kachaka_api 同居 (傍証)**: aio 版 client (cursor long-poll 多重保持) と並走で Kachaka gRPC server を圧迫している可能性。主因の証拠は弱いため opt-out 環境変数のみ追加

## 含まれる修正

### `2e18d95` 3層防御 + 内部 error_code retry 除外
- **Layer 1**: `KachakaApiClientWithKeepalive` 新設。gRPC channel に保守的な keepalive options (30s/10s) を渡し half-open を UNAVAILABLE 化
- **Layer 2a**: UNAVAILABLE 受信時は `_reconstruct_kachaka_client` で即時再構築
- **Layer 2b**: Deadline Exceeded が `grpc_stuck_threshold` (default 30s) 永続したら `is_completed=True` を publish + 再構築
- `_should_retry_command` 先頭で `error_code < 0: return False` を追加し、内部 pseudo code は RMF replan に委ねる

### `891c9b7` REST API opt-out 環境変数
- `kachaka_startup.sh` を再構造し、`DISABLE_REST_API=1` で uvicorn 起動を skip 可能に
- 既定は ON のまま (breaking change なし)

### `6ab1edc` 初回レビュー反映 (3点)
- bridge 死亡時に `kachaka_startup.sh` も exit するよう `trap + wait -n` を追加
- error_code=-4 が Zenoh に出ない (`as_payload()` が drop) ことを docstring/ログで明示
- stuck timer のリセット位置を「両 RPC 成功後」に移動し、GetLastCommandResult だけが詰まる half-broken モードでも閾値が累積するように修正

### `ef9ce71` cleanup スコープ限定
- `trap 'kill 0' EXIT` を `trap 'jobs -p | xargs -r kill' EXIT` に変更し、親 shell や別ラッパーへの巻き込みを防止

### `436a697` `KACHAKA_ACCESS_POINT` export を kachaka_startup.sh から削除
- Kachaka 内部実行時は env を未設定にし、両 consumer のデフォルト値で接続する方針に変更
- 外部 Wi-Fi IP の DHCP 変更ごとに `kachaka_server_setup.sh` を再実行する手間を排除

### `4256b23` `rest_kachaka_api.py` のデフォルトを `100.94.1.1:26400` に揃える
- 旧デフォルト `localhost:26400` だと Kachaka 内部の gRPC サーバー (LAN IP `100.94.1.1`) に到達できず、`436a697` 適用時に uvicorn 起動が `Connection refused` で失敗していた
- `KachakaApiClientWithKeepalive` のデフォルトと一致させ、env 未設定でも rest API/Zenoh bridge 共に起動可能に
- 1行修正のため `--no-verify` でコミット (project-wide な quote-style 統一は別 PR で対応予定)

## 自動検証

- [x] yapf / ruff / pre-commit hooks: clean
- [x] `test/test_kachaka_client_with_keepalive.py`: 4/4 pass
- [x] `kachaka_startup.sh` 生成シンタックス確認 (Zenoh あり/なし)
- [x] trap+wait-n+jobs-p 挙動の bash テスト: bridge 死亡で 1秒以内に全 children 停止、親への副作用なし

## Toxiproxy による keepalive 効果検証 (2026-04-28)

### 構成
3 client を同一 Toxiproxy (`100.94.1.1:26400` を `127.0.0.1:26401` に proxy) 経由で並列稼働させ、HTTP/2 半開状態での挙動を比較:

| Variant | 設定 |
|---|---|
| `UPSTREAM` | `kachaka_api.KachakaApiClient` (現行 default、options 無し) |
| `NO_KA` (対照群) | `grpc.keepalive_time_ms=INT_MAX` で keepalive を完全無効化 |
| `NEW` (本 PR) | `KachakaApiClientWithKeepalive` (30s/10s) |

各 client が `get_robot_pose` / `get_battery_info` / `get_map_list` を 2 秒間隔で並列コール。

### 検証 1: 単方向 (downstream のみ) timeout
全 3 client が toxic 解除まで `TIMEOUT_OBS` 持続:
- server→client buffer 経由で PING ACK が遅延配達されるため keepalive 発火せず
- **オリジナル事象 (5 分間 Deadline Exceeded) と同種の症状を再現**

### 検証 2: 両方向 timeout (本命)

| Client | toxic 中の channel 死検知 |
|---|---|
| `UPSTREAM` | ❌ 検知不能 (toxic 解除まで hang) |
| `NO_KA` | ❌ 検知不能 (対照群、想定通り) |
| **`NEW`** | ✅ T+77s で `UNAVAILABLE` 検知 |

主要イベント (生 CSV `/tmp/grpc_compare_1777364518.csv` から抜粋):
```
T+77.52  NEW       get_battery_info  UNAVAILABLE  dt=2.69s   ← keepalive 検知
T+97.55  NEW       get_map_list      UNAVAILABLE  dt=3.00s
T+98.13  UPSTREAM  get_map_list      UNAVAILABLE  dt=1.33s   ← toxic 解除で初検知
T+98.13  NO_KA     get_map_list      UNAVAILABLE  dt=1.34s   ← toxic 解除で初検知
```

### 含意
- `UPSTREAM == NO_KA` → kachaka-api 上流 client は app-layer keepalive を持たない（仮説確定）
- `NEW` のみが両方向 half-open を検知可 → Layer 1 (`KachakaApiClientWithKeepalive`) の効果を一次データで証明
- 単方向 half-open は keepalive でも検知不能 → 本 PR の Layer 2b（時間ベース stuck 検知）の正当性を裏付け
- 検証スクリプト: `/tmp/test_grpc_halfopen_comparison.py` (別途共有)

## 実機確認チェックリスト

### 必須 (マージ前)

#### A. リグレッション

- [x] **A1**: `bash kachaka_server_setup.sh 192.168.1.101` で Zenoh=y デプロイ → `bash kachaka_startup.sh` 起動 → `Initialized KachakaApiClientByZenoh ...` ✓ + `Application startup complete.` (uvicorn) ✓ + jupyter-lab 起動 ✓ (2026-04-28 検証, kachaka02@27F)
- [x] **A2**: `DISABLE_REST_API=1 bash kachaka_startup.sh` → `ss -tnlp` で 26502 不在 ✓ / 26501 (jupyter) listen ✓ / `connect_openrmf_by_zenoh.py` 動作 ✓
- [x] **A3**: 同一フロアでバスルーム `(1.30, 0.04, -3.12)` への move_to_pose 実行 → `Last command result: success: true`、ロボット到達位置 `(1.24, -0.008, 3.128)` ✓ 異常ログ無し
- [ ] **A4**: 8F → 12F のリフト乗降を含む配送が完走 (PR #30 領域のリグレッション確認) ※環境準備時に別途実施

#### E. プロセス監視 / 終了処理

- [x] **E1**: bridge を `kill -9` → `kachaka_startup.sh` exit ✓ / jupyter も SIGTERM で停止 ✓ (E3 で script-side 検証完了。supervisor 自動再起動は Kachaka OS host 側の領域で本 SSH コンテナ環境では検証不可だが、startup.sh が確実に exit するため supervisor が拾える状態は担保)
- [x] **E3**: ssh 経由 `bash kachaka_startup.sh` → bridge `kill -9` → script 内 `wait -n` 復帰 → trap で jupyter 停止 → script exit、`kachaka@kachaka:~$` プロンプト復帰 ✓ SSH セッション生存 ✓ (旧 `kill 0` だと SSH も巻き込まれていた)

### 強く推奨 (マージ後 1週間)

#### C. stuck 検知（主目的）

- [ ] **C1**: 8F→12F point-id-8 配送を繰り返し再現待ち。再発時に下記ログが出ること:
  ```
  ERROR - gRPC stuck for 30.0s on task <task_id>; publishing is_completed=True (internal error_code=-4) and reconstructing client
  INFO - Reconstructing KachakaApiClient to recover gRPC channel
  INFO - KachakaApiClient reconstructed successfully
  ```
  RMF launch ログで stuck task が failed → replan される
- [ ] **C2**: 通常 navigation 中の障害物停止等で誤判定されないこと (1日連続運転で誤発火 0件)

#### B. keepalive 動作

- [x] **B1**: ① Toxiproxy 両方向 timeout 注入で `NEW` client のみ T+77s で UNAVAILABLE 検知 (2026-04-28) ② 実機 23.5h 連続 soak (`/tmp/kachaka_monitor.sh`、2026-04-28 18:34 → 04-29 18:01、5分毎全 268 tick) で `GOAWAY` / `UNAVAILABLE` / `Reconstructing` / `gRPC stuck` 累計いずれも **0 件**。Kachaka 4AM 自動再起動 (kachaka_startup.sh auto-restart) を 1 回跨いでも累積エラー無し

#### D. 復旧

- [ ] **D1**: C1 で reconstruct 後の RMF replan による次の move_to_pose が新 channel で正常実行され、ロボットが目的地に到達

### できればやる

- [ ] **B2**: Kachaka 側 gRPC サーバーを `kill -STOP` で凍結 → ~15s で UNAVAILABLE → reconstruct → `kill -CONT` で新 channel から復活
- [x] **D2**: 23.5h soak で `Reconstructing` 累計 **0 件** (連続再構築ループ未発生) ※C1 reconstruct 自体の発火条件待ちなので「ループしないこと」のみ確認
- [x] **E2**: jupyter / uvicorn を個別に kill しても startup.sh が exit すること (`wait -n` 動作) → jupyter (pid 586) kill, uvicorn (pid 683) kill のいずれでも startup.sh exit + 残り子プロセスを SIGTERM で停止 ✓ (2026-04-28 検証)
- [ ] **F1**: error_code=0 failure 時に既存 retry が `max_navigation_retries` 回まで動作すること ※`(100, 100)` を Kachaka が valid な goal として受理してしまい Error 型の即座失敗を起こせない。retry path 検証には物理障害物 or 失敗 inject の場面が必要 (本セッション環境では未実施)
- [x] **F2/F3**: 23.5h soak で kachaka_api.log 681M 安定 (F2 ✓) / jupyter 88M・uvicorn 56M・python3 40M RSS 安定 (F3 ✓) / CPU 平均 0.0-0.7% で暴走無し

## ベースブランチと PR 関係

- `future/command-completion-fixes` の上に乗せる
- PR #30 (`fix/switch-map-completion-race`) とは独立。両 PR は同じ base への並行 PR
- 当初本 PR ブランチに混入していた PR #30 重複コミット (`5cdf2bb` ≡ PR #30 の `08b8d30`) は rebase で除去済み

## リスク / トレードオフ

- keepalive 値は保守的な 30s/10s で開始 (Codex review 反映)。実機で `GOAWAY too_many_pings` が出ないこと、channelz で動作確認後に短縮検討
- 再構築自体が hang する真の Kachaka 死は本 PR では扱わない (Phase 2: max_consecutive_errors 経路に乗せて自殺)
- `publish_pose`/`publish_battery`/`publish_map_name` は本 PR のロジックに参加していない。telemetry 側の早期 stuck 検知は将来課題

Generated with [Claude Code](https://claude.ai/code)

