### PR TITLE
cleanup: 不要な KACHAKA_ACCESS_POINT export を kachaka_startup.sh から削除

### DIFF
--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -38,10 +38,6 @@ cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
 export KACHAKA_IP=$KACHAKA_IP
-# When running on the Kachaka robot internally, KACHAKA_ACCESS_POINT is optional
-if [ -n "$KACHAKA_IP" ]; then
-  export KACHAKA_ACCESS_POINT=\$KACHAKA_IP:26400
-fi
 export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export LOG_LEVEL=$LOG_LEVEL


### PR DESCRIPTION
## 概要

`kachaka_server_setup.sh` が生成する `kachaka_startup.sh` から `KACHAKA_ACCESS_POINT` の export を削除します。

## 背景

`kachaka_startup.sh` は scp で Kachaka ロボット本体に転送され、ロボット内部で実行されます (`kachaka_server_setup.sh:71`)。両方の利用側コードはローカル接続にフォールバックするため、internal 実行時に環境変数の指定は不要です。

- `scripts/rest_kachaka_api.py:44` — `os.getenv("KACHAKA_ACCESS_POINT", "localhost:26400")` でデフォルト `localhost:26400`
- `scripts/connect_openrmf_by_zenoh.py:201-203` — `kachaka_access_point` が None の場合は `KachakaApiClientWithKeepalive()` を引数なしで呼び、内部のデフォルト（localhost）を使う

しかも現状の設定 `$KACHAKA_IP:26400` は、ロボット自身の外部 IP を経由してネットワーク往復することになり、`localhost` の方が望ましい挙動です。

`b6eec13` (`feat: make KACHAKA_ACCESS_POINT optional when running internally`) でコード側はオプショナル化されましたが、setup スクリプト側に export が残ってしまっていたものを今回削除します。

## テスト計画

- [ ] `kachaka_server_setup.sh <ip>` を実行し、生成された `kachaka_startup.sh` から export ブロックが消えていることを確認
- [ ] Kachaka 実機にデプロイ後、REST API (`uvicorn`) と Zenoh ブリッジ (`connect_openrmf_by_zenoh.py`) が localhost 接続で正常起動することを確認