### PR TITLE
fix: コマンド完了処理・switch_mapレース・gRPC stuck検知を統合

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,7 @@ timeouts:
   running_state_wait: 5.0   # Max wait time for RUNNING state after command sent
   grpc_telemetry: 5.0       # Timeout for telemetry gRPC calls (get_robot_pose, etc.)
   grpc_status_check: 5.0    # Timeout for command status gRPC calls (GetCommandState, etc.)
+  grpc_stuck: 30.0          # Threshold (sec) for treating persistent Deadline Exceeded as a stuck channel
 
 intervals:
   command_check: 4.0        # How often to check for new commands

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -22,7 +22,7 @@ if ! nc -z -w $timeout $KACHAKA_IP $SSH_PORT; then
     echo "See https://github.com/pf-robotics/kachaka-api?tab=readme-ov-file#playground%E3%81%ABssh%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B"
     exit 1
 fi
-RUN_LINE="jupyter-lab --port=26501 --ip='0.0.0.0' & uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502"
+RUN_ZENOH=""
 # Ask whether to set up Zenoh client. If yes, ask the router access point and the robot name.
 read -p "Do you want to set up the Zenoh client? (y/n) " -n 1 -r
 echo
@@ -31,9 +31,12 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
   read -p "Enter the robot name: " ROBOT_NAME
   read -p "Enter log level (DEBUG/INFO/WARNING/ERROR/CRITICAL) [INFO]: " LOG_LEVEL
   LOG_LEVEL=${LOG_LEVEL:-INFO}
-  RUN_LINE="$RUN_LINE & python3 sbgisen/connect_openrmf_by_zenoh.py"
+  RUN_ZENOH=1
 fi
-# Create the server setup script with dynamic KACHAKA_IP
+# Create the server setup script with dynamic KACHAKA_IP.
+# REST API (uvicorn) is launched by default; set DISABLE_REST_API=1 in the
+# Kachaka environment to skip it (useful for OpenRMF-only deployments and
+# for diagnosing gRPC server load issues).
 cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
@@ -46,7 +49,12 @@ export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export LOG_LEVEL=$LOG_LEVEL
 export PATH=/home/kachaka/.local/bin:\$PATH
-$RUN_LINE
+jupyter-lab --port=26501 --ip='0.0.0.0' &
+if [ "\${DISABLE_REST_API:-0}" != "1" ]; then
+  uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502 &
+fi
+${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
+wait
 EOF
 
 ssh -p $SSH_PORT kachaka@$KACHAKA_IP <<EOF

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -41,10 +41,6 @@ cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
 export KACHAKA_IP=$KACHAKA_IP
-# When running on the Kachaka robot internally, KACHAKA_ACCESS_POINT is optional
-if [ -n "$KACHAKA_IP" ]; then
-  export KACHAKA_ACCESS_POINT=\$KACHAKA_IP:26400
-fi
 export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export LOG_LEVEL=$LOG_LEVEL

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -56,7 +56,9 @@ fi
 ${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
 # Exit when any child process dies so the supervisor can restart the whole stack
 # (matches the original foreground-bridge behaviour where bridge death exited the script).
-trap 'kill 0' EXIT
+# Use jobs -p to limit the cleanup to processes this script started; kill 0 would
+# also signal the parent shell or unrelated members of the same process group.
+trap 'jobs -p | xargs -r kill 2>/dev/null' EXIT
 wait -n
 EOF
 

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -54,7 +54,10 @@ if [ "\${DISABLE_REST_API:-0}" != "1" ]; then
   uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502 &
 fi
 ${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
-wait
+# Exit when any child process dies so the supervisor can restart the whole stack
+# (matches the original foreground-bridge behaviour where bridge death exited the script).
+trap 'kill 0' EXIT
+wait -n
 EOF
 
 ssh -p $SSH_PORT kachaka@$KACHAKA_IP <<EOF

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -854,19 +854,27 @@ class KachakaApiClientByZenoh:
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:
-                response = self._execute_sync_method('switch_map', payload)
-                # Update command context if switch_map did not raise an exception.
-                # Note: switch_map response may lack 'result' field, so we check
-                # both formats: with result.success and without result (assume success).
+                # Suppress automatic completion in _execute_sync_method so we can
+                # publish map_name to Zenoh *before* notifying RMF of completion.
+                # This prevents a race where RMF receives the completion, queries
+                # the robot's map_name (still the old floor), and issues a
+                # navigation command with stale floor coordinates.
+                response = self._execute_sync_method('switch_map', payload, publish_completion=False)
                 success = True
                 if response and isinstance(response, dict) and 'result' in response:
                     success = response['result'].get('success', False)
                 if success:
-                    self._command_context_map_name = args.get('map_name')
+                    rmf_map_name = args.get('map_name')
+                    self._command_context_map_name = rmf_map_name
+                    self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
+                    self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                     self.logger.info(
-                        'Updated command_context_map_name after successful switch_map: %s',
-                        self._command_context_map_name,
+                        'Published map_name=%s to Zenoh after successful switch_map',
+                        rmf_map_name,
                     )
+                    self._publish_command_completion(success=True, error_code=0)
+                else:
+                    self._publish_command_completion(success=False, error_code=-1)
         except RpcError as e:
             self._log_error('RPC', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
@@ -874,12 +882,20 @@ class KachakaApiClientByZenoh:
             self._log_error('Unexpected', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
 
-    def _execute_sync_method(self, method_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Execute a method synchronously and publish completion status.
+    def _execute_sync_method(
+        self,
+        method_name: str,
+        args: Dict[str, Any],
+        publish_completion: bool = True,
+    ) -> Dict[str, Any]:
+        """Execute a method synchronously and optionally publish completion status.
 
         Args:
             method_name (str): The name of the method to execute
             args (Dict[str, Any]): The arguments for the method
+            publish_completion (bool): Whether to automatically publish completion
+                status. Set to False when the caller needs to perform additional
+                state updates (e.g., publishing map_name) before notifying RMF.
 
         Returns:
             Dict[str, Any]: The response from the method
@@ -888,7 +904,7 @@ class KachakaApiClientByZenoh:
             if not self.grpc_connection_check():
                 error_msg = f'Failed to connect to Kachaka API server for method {method_name}'
                 self.logger.error(error_msg)
-                if self.task_id:
+                if self.task_id and publish_completion:
                     self._publish_command_completion(success=False, error_code=-1)
                 raise ConnectionError(error_msg)
 
@@ -909,16 +925,17 @@ class KachakaApiClientByZenoh:
                     self.logger.info(f'Async command {method_name} started')
                 elif success:
                     self.logger.info(f'Command {method_name} completed successfully')
-                    # Synchronous command completed successfully
-                    self._publish_command_completion(success=True, error_code=0)
+                    if publish_completion:
+                        self._publish_command_completion(success=True, error_code=0)
                 else:
                     self._log_warning(f'Command {method_name} failed with error_code={error_code}')
-                    # Always publish failure immediately
-                    self._publish_command_completion(success=False, error_code=error_code)
+                    if publish_completion:
+                        self._publish_command_completion(success=False, error_code=error_code)
             else:
                 # No result field (e.g., switch_map), assume success
                 self.logger.info(f'Command {method_name} executed successfully')
-                self._publish_command_completion(success=True, error_code=0)
+                if publish_completion:
+                    self._publish_command_completion(success=True, error_code=0)
 
             return response
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -984,11 +984,14 @@ class KachakaApiClientByZenoh:
 
         MessageToDict drops zero-valued fields, so a plain success serializes
         to {'success': True} and a failure with a non-zero code to
-        {'errorCode': N}. A Result with success=False and error_code=0
+        {'errorCode': N}. A bare Result with success=False and error_code=0
         therefore serializes to {} and is indistinguishable from a response
-        that carries no Result at all; both yield None (callers treat None as
-        success). This edge does not occur for the dispatch-time results
-        handled here, where failures always carry a non-zero error code.
+        that carries no Result at all; both yield None and callers treat None
+        as success. (The wrapped {'result': {...}} branch instead returns the
+        nested dict verbatim, so an empty {'result': {}} yields {} and is read
+        as success=False.) This ambiguous bare case does not occur for the
+        dispatch-time results handled here, where failures always carry a
+        non-zero error code.
         """
         if not isinstance(response, dict):
             return None

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -235,7 +235,6 @@ class KachakaApiClientByZenoh:
         self.last_pose = Pose.zero()
         self.last_battery = 100.0
         self.map_state = MapState.initial()
-        self._command_context_map_name: Optional[str] = None
         self.last_command = None
         self.last_command_result = None
         self.last_command_id = None
@@ -424,31 +423,43 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
+    def _fetch_robot_map_name(self, timeout: float) -> str:
+        """Fetch the robot's actual current map name via gRPC.
+
+        Queries GetMapList and GetCurrentMapId on the robot and applies the
+        reverse name mapping so the returned value is the RMF-side map name.
+        This is the single source of truth for the robot's current map.
+
+        Args:
+            timeout (float): The timeout in seconds for each gRPC call.
+
+        Returns:
+            str: The RMF-side name of the map the robot is currently on.
+
+        Raises:
+            RpcError: If either gRPC call fails or times out.
+        """
+        map_list_response = self.kachaka_client.stub.GetMapList(pb2.GetRequest(), timeout=timeout)
+        map_id_response = self.kachaka_client.stub.GetCurrentMapId(pb2.GetRequest(), timeout=timeout)
+
+        search_id = map_id_response.id
+        kachaka_map_name = next(
+            (entry.name for entry in map_list_response.map_list_entries if entry.id == search_id),
+            'L1',
+        )
+        return self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
+
     async def publish_map_name(self) -> None:
         """Publish the current map name to Zenoh.
 
-        Gets the current map ID from Kachaka via gRPC stub with timeout,
-        looks up the map name, applies name mapping, and publishes to Zenoh.
-        On timeout, publishes cached value to keep the telemetry loop running.
+        Gets the current map name from Kachaka via gRPC with timeout and
+        publishes it to Zenoh. On timeout, publishes cached value to keep
+        the telemetry loop running.
         """
         method_name = 'publish_map_name'
         try:
-            map_list_response = self.kachaka_client.stub.GetMapList(pb2.GetRequest(),
-                                                                    timeout=self.grpc_telemetry_timeout)
-            map_id_response = self.kachaka_client.stub.GetCurrentMapId(pb2.GetRequest(),
-                                                                       timeout=self.grpc_telemetry_timeout)
-
-            search_id = map_id_response.id
-            kachaka_map_name = next(
-                (entry.name for entry in map_list_response.map_list_entries if entry.id == search_id),
-                'L1',
-            )
-            map_name = self.reverse_map_name_mapping.get(kachaka_map_name, kachaka_map_name)
+            map_name = self._fetch_robot_map_name(self.grpc_telemetry_timeout)
             self.map_state = self.map_state.with_telemetry_map_name(map_name)
-            with self._command_lock:
-                if self._command_context_map_name is None:
-                    self._command_context_map_name = map_name
-
             self._publish_to_zenoh(self.map_name_pub, map_name)
         except RpcError as e:
             if e.code() == StatusCode.DEADLINE_EXCEEDED:
@@ -838,6 +849,53 @@ class KachakaApiClientByZenoh:
         # error_code=-3: task was replaced by a newer command before completion.
         self._publish_command_completion(success=False, error_code=-3)
 
+    def _verify_map_for_navigation(self, requested_map_name: str) -> bool:
+        """Check that the robot is on the requested map before navigating.
+
+        Compares against the telemetry map name, which is the same value
+        reported to RMF, so the guard can never disagree with what RMF sees.
+        On mismatch the robot is re-queried via gRPC before rejecting: the
+        cached value can diverge from the robot when a switch_map result is
+        lost or the map is changed outside this bridge (e.g. from the
+        smartphone app), and without the re-query a stale cache would reject
+        every navigation command until restart.
+
+        Args:
+            requested_map_name (str): The RMF-side map name of the navigation command.
+
+        Returns:
+            bool: True if navigation may proceed. False if the robot is on a
+                different map or its map could not be determined; a failure
+                completion (error_code=-2) is published in that case.
+        """
+        if requested_map_name == self.map_state.telemetry_map_name:
+            return True
+
+        try:
+            current_map_name = self._fetch_robot_map_name(self.grpc_status_check_timeout)
+        except RpcError as e:
+            self._log_error('RPC', '_verify_map_for_navigation', e)
+            self._log_warning(
+                f'Could not verify current map for navigation to {requested_map_name}. Rejecting navigation command.')
+            self._publish_command_completion(success=False, error_code=-2)
+            return False
+
+        self.map_state = self.map_state.with_telemetry_map_name(current_map_name)
+        self._publish_to_zenoh(self.map_name_pub, current_map_name)
+
+        if requested_map_name == current_map_name:
+            self._log_info(
+                f'Cached map name was stale; robot is actually on {current_map_name}. Proceeding with navigation.')
+            return True
+
+        # Map name mismatch indicates RMF has incorrect floor information.
+        # Reject the navigation command and return error to trigger replanning.
+        self._log_warning(f'Map name mismatch: requested={requested_map_name}, '
+                          f'current={current_map_name}. '
+                          f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
+        self._publish_command_completion(success=False, error_code=-2)
+        return False
+
     def _execute_command(self, command: Dict[str, Any]) -> None:
         """Unified command execution logic."""
         method_name = 'execute_command'
@@ -872,15 +930,7 @@ class KachakaApiClientByZenoh:
                 elif method_name == 'move_to_pose':
                     args = command['args'].copy()
                     map_name = args.pop('map_name', None)
-                    if (map_name is not None and self._command_context_map_name is not None and
-                            map_name != self._command_context_map_name):
-                        # Map name mismatch indicates RMF has incorrect floor information.
-                        # Reject the navigation command and return error to trigger replanning.
-                        self._log_warning(
-                            f'Map name mismatch: requested={map_name}, '
-                            f'current={self._command_context_map_name}. '
-                            f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
-                        self._publish_command_completion(success=False, error_code=-2)
+                    if map_name is not None and not self._verify_map_for_navigation(map_name):
                         return
                     args = self._prepare_async_command_args(args, {'cancel_all': True})
                     self.logger.debug(f'Current pose: {self.last_pose.as_list()}')
@@ -939,7 +989,6 @@ class KachakaApiClientByZenoh:
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
                 rmf_map_name = args.get('map_name')
-                self._command_context_map_name = rmf_map_name
                 self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
                 self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                 self.logger.info('Nothing to do - already on target map')
@@ -955,7 +1004,6 @@ class KachakaApiClientByZenoh:
                 success = result_dict.get('success', False) if result_dict is not None else True
                 if success:
                     rmf_map_name = args.get('map_name')
-                    self._command_context_map_name = rmf_map_name
                     self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
                     self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                     # Pose must precede completion: RMF reading (new map_name, stale pose) triggers "too far" replan.
@@ -973,10 +1021,54 @@ class KachakaApiClientByZenoh:
                     self._publish_command_completion(success=False, error_code=-1)
         except RpcError as e:
             self._log_error('RPC', method_name, e)
-            self._publish_command_completion(success=False, error_code=-1)
+            if not self._recover_interrupted_switch_map(args):
+                self._publish_command_completion(success=False, error_code=-1)
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
-            self._publish_command_completion(success=False, error_code=-1)
+            if not self._recover_interrupted_switch_map(args):
+                self._publish_command_completion(success=False, error_code=-1)
+
+    def _recover_interrupted_switch_map(self, args: Dict[str, Any]) -> bool:
+        """Complete a failed-looking switch_map that actually took effect.
+
+        A switch_map gRPC call can succeed on the robot while its response is
+        lost (e.g. DEADLINE_EXCEEDED). Reporting failure in that case leaves
+        the cached map name on the old floor while the robot is already on
+        the new one, so every later move_to_pose would be rejected by the map
+        guard. Re-query the robot and, when it is already on the target map,
+        publish the fresh map_name and actual pose before completing the
+        command as a success, mirroring the normal success path.
+
+        Args:
+            args (dict): The original switch_map arguments.
+
+        Returns:
+            bool: True if the switch was confirmed on the robot and a success
+                completion was published. False if the robot is not on the
+                target map or could not be queried; the caller should publish
+                the failure completion in that case.
+        """
+        rmf_map_name = args.get('map_name')
+        if rmf_map_name is None:
+            return False
+        try:
+            current_map_name = self._fetch_robot_map_name(self.grpc_status_check_timeout)
+            if current_map_name != rmf_map_name:
+                return False
+            response = self.kachaka_client.stub.GetRobotPose(pb2.GetRequest(), timeout=self.grpc_status_check_timeout)
+            pose = Pose(response.pose.x, response.pose.y, response.pose.theta)
+        except Exception as e:
+            self._log_error('Unexpected', '_recover_interrupted_switch_map', e)
+            return False
+
+        self._log_info(f'switch_map result was lost but robot is already on {rmf_map_name}; completing as success')
+        self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
+        self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
+        # Pose must precede completion: RMF reading (new map_name, stale pose) triggers "too far" replan.
+        self.last_pose = pose
+        self._publish_to_zenoh(self.pose_pub, pose.as_list())
+        self._publish_command_completion(success=True, error_code=0)
+        return True
 
     @staticmethod
     def _extract_command_result(response: Any) -> Optional[Dict[str, Any]]:  # noqa: ANN401

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -958,8 +958,14 @@ class KachakaApiClientByZenoh:
                     self._command_context_map_name = rmf_map_name
                     self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
                     self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
+                    # Pose must precede completion: RMF reading (new map_name, stale pose) triggers "too far" replan.
+                    target_pose = payload['pose']
+                    new_pose = Pose(target_pose.get('x', 0.0), target_pose.get('y', 0.0),
+                                    target_pose.get('theta', 0.0))
+                    self.last_pose = new_pose
+                    self._publish_to_zenoh(self.pose_pub, new_pose.as_list())
                     self.logger.info(
-                        'Published map_name=%s to Zenoh after successful switch_map',
+                        'Published map_name=%s and target pose to Zenoh after successful switch_map',
                         rmf_map_name,
                     )
                     self._publish_command_completion(success=True, error_code=0)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -54,10 +54,9 @@ class Pose:
 class CommandCompletion:
     """Internal command completion state.
 
-    success and error_code are kept on the instance for the Kachaka-side retry
-    logic but are NOT published over Zenoh — see as_payload(). The signal that
-    actually reaches RMF is is_completed; flipping it to True for an active
-    task is what unblocks RMF from a stuck-running state.
+    as_payload() publishes {id, is_completed, success} to Zenoh.
+    error_code is kept on the instance for the Kachaka-side retry logic
+    but is NOT published — see as_payload().
 
     error_code values used internally (not transmitted):
         0   : success
@@ -81,13 +80,15 @@ class CommandCompletion:
     def as_payload(self) -> Dict[str, Any]:
         """Return the payload for Zenoh publishing.
 
-        Only includes fields that consumers (fleet_adapter, lci_lift_request_converter) use.
-        success/error_code are internal state for retry logic and not published.
+        error_code is internal state for retry logic and not published.
         """
-        return {
+        payload: Dict[str, Any] = {
             'id': self.task_id,
             'is_completed': self.is_completed,
         }
+        if self.is_completed and self.success is not None:
+            payload['success'] = self.success
+        return payload
 
 
 @dataclass(frozen=True)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -439,33 +439,46 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
-    async def _handle_command_retry(self, error_code: int) -> bool:
+    async def _handle_command_retry(self, task_id: str, error_code: int) -> bool:
         """Handle retry logic for failed commands.
 
         Args:
+            task_id: The task ID that produced the failed result
             error_code: The error code from the failed command
 
         Returns:
             True if retry was initiated (caller should return early), False otherwise
         """
-        if not self.retry_enabled or self.retry_count >= self.max_navigation_retries:
-            if self.retry_count >= self.max_navigation_retries:
-                self._log_error_msg(f'Max retries ({self.max_navigation_retries}) exceeded for command {self.task_id}')
-            return False
-
         should_retry = await self._should_retry_command(error_code)
         if not should_retry:
             self._log_info(f'Error code {error_code} is not retriable')
             return False
 
-        self.retry_count += 1
-        self._log_info(f'Retrying command (attempt {self.retry_count}/{self.max_navigation_retries})')
+        with self._command_lock:
+            if self.task_id != task_id:
+                self.logger.debug('Skip retry for stale task %s (active task: %s)', task_id, self.task_id)
+                return False
+            if not self.retry_enabled or self.retry_count >= self.max_navigation_retries:
+                if self.retry_count >= self.max_navigation_retries:
+                    self._log_error_msg(f'Max retries ({self.max_navigation_retries}) exceeded for command {task_id}')
+                return False
+            if not self.last_command:
+                return False
+
+            self.retry_count += 1
+            retry_count = self.retry_count
+            command_to_retry = self.last_command.copy()
+
+        self._log_info(f'Retrying command (attempt {retry_count}/{self.max_navigation_retries})')
 
         await asyncio.sleep(self.retry_interval)
-        if self.last_command:
-            self._execute_command(self.last_command)
-            return True
-        return False
+        with self._command_lock:
+            if self.task_id != task_id:
+                self.logger.debug('Cancel retry for stale task %s (active task: %s)', task_id, self.task_id)
+                return False
+
+        self._execute_command(command_to_retry)
+        return True
 
     async def publish_result(self) -> None:
         """Publish command completion status to Zenoh.
@@ -474,6 +487,8 @@ class KachakaApiClientByZenoh:
         Uses command_id to ensure state/result pairs belong to the active command.
         """
         method_name = 'publish_result'
+        retry_task_id: Optional[str] = None
+        retry_error_code: Optional[int] = None
         try:
             with self._command_lock:
                 if not self.task_id:
@@ -574,8 +589,16 @@ class KachakaApiClientByZenoh:
                         self.retry_count = 0
                     else:
                         self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
-                        if await self._handle_command_retry(error_code):
-                            return  # Retry initiated, don't publish yet
+                        retry_task_id = self.task_id
+                        retry_error_code = error_code
+
+            if retry_task_id is not None and retry_error_code is not None:
+                if await self._handle_command_retry(retry_task_id, retry_error_code):
+                    return  # Retry initiated, don't publish yet
+
+            with self._command_lock:
+                if retry_task_id is not None and self.task_id != retry_task_id:
+                    return
 
                 # Publish and reset
                 self.last_command_result = result

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -54,14 +54,17 @@ class Pose:
 class CommandCompletion:
     """Internal command completion state.
 
-    error_code values used internally:
+    success and error_code are kept on the instance for the Kachaka-side retry
+    logic but are NOT published over Zenoh — see as_payload(). The signal that
+    actually reaches RMF is is_completed; flipping it to True for an active
+    task is what unblocks RMF from a stuck-running state.
+
+    error_code values used internally (not transmitted):
         0   : success
         -1  : unknown / format error
         -2  : map name mismatch
         -3  : superseded by a new command
         -4  : gRPC channel persistently stuck (Deadline Exceeded > grpc_stuck threshold)
-
-    Negative error_codes are internal signals to RMF for replan; not retriable on Kachaka side.
     """
 
     task_id: str
@@ -518,7 +521,6 @@ class KachakaApiClientByZenoh:
                     return
 
                 state_res = self._get_command_state_response()
-                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
@@ -564,6 +566,8 @@ class KachakaApiClientByZenoh:
                         return
 
                 last_result = self._get_last_command_result_response()
+                # Both GetCommandState and GetLastCommandResult succeeded; reset stuck timer.
+                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetLastCommandResult response: {last_result}')
                 result_command_id = last_result.get('commandId')
 
@@ -645,8 +649,12 @@ class KachakaApiClientByZenoh:
                         self._first_grpc_failure_time = now
                     elif now - self._first_grpc_failure_time >= self.grpc_stuck_threshold:
                         stuck_task = self.task_id
-                        self._log_error_msg(f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
-                                            f'publishing failure (error_code=-4) and reconstructing client')
+                        self._log_error_msg(
+                            f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
+                            f'publishing is_completed=True (internal error_code=-4) and reconstructing client')
+                        # error_code=-4 is internal-only; CommandCompletion.as_payload() drops it.
+                        # The signal that reaches RMF is is_completed=True, which unblocks the
+                        # adapter from treating the task as still running.
                         fail_result = CommandCompletion(
                             task_id=stuck_task,
                             is_completed=True,

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -951,9 +951,8 @@ class KachakaApiClientByZenoh:
                 # the robot's map_name (still the old floor), and issues a
                 # navigation command with stale floor coordinates.
                 response = self._execute_sync_method('switch_map', payload, publish_completion=False)
-                success = True
-                if response and isinstance(response, dict) and 'result' in response:
-                    success = response['result'].get('success', False)
+                result_dict = self._extract_command_result(response)
+                success = result_dict.get('success', False) if result_dict is not None else True
                 if success:
                     rmf_map_name = args.get('map_name')
                     self._command_context_map_name = rmf_map_name
@@ -972,6 +971,32 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
+
+    @staticmethod
+    def _extract_command_result(response: Any) -> Optional[Dict[str, Any]]:  # noqa: ANN401
+        """Return the command Result dict from a method response, or None.
+
+        The kachaka high-level client's start_command() unwraps
+        StartCommandResponse and returns the bare Result message, so async
+        commands (move_to_pose, return_home) and switch_map arrive as
+        {'success': ..., 'errorCode': ...} with no nested 'result' key. The
+        wrapped {'result': {...}} shape is also accepted for safety.
+
+        MessageToDict drops zero-valued fields, so a plain success serializes
+        to {'success': True} and a failure with a non-zero code to
+        {'errorCode': N}. A Result with success=False and error_code=0
+        therefore serializes to {} and is indistinguishable from a response
+        that carries no Result at all; both yield None (callers treat None as
+        success). This edge does not occur for the dispatch-time results
+        handled here, where failures always carry a non-zero error code.
+        """
+        if not isinstance(response, dict):
+            return None
+        if isinstance(response.get('result'), dict):
+            return response['result']
+        if 'success' in response or 'errorCode' in response:
+            return response
+        return None
 
     def _execute_sync_method(
         self,
@@ -1002,20 +1027,7 @@ class KachakaApiClientByZenoh:
             method = getattr(self.kachaka_client, method_name)
             response = self._to_dict(method(**args))
 
-            # Extract the command Result. The kachaka high-level client's
-            # start_command() unwraps StartCommandResponse and returns the bare
-            # Result message, so async commands (move_to_pose, return_home)
-            # arrive as {'success': ..., 'errorCode': ...} with no nested
-            # 'result' key. Handle both the bare Result and the wrapped shape;
-            # MessageToDict converts snake_case to camelCase (error_code ->
-            # errorCode) and drops zero-valued fields.
-            result_dict: Optional[Dict[str, Any]] = None
-            if isinstance(response, dict):
-                if isinstance(response.get('result'), dict):
-                    result_dict = response['result']
-                elif 'success' in response:
-                    result_dict = response
-
+            result_dict = self._extract_command_result(response)
             if result_dict is not None:
                 success = result_dict.get('success', False)
                 error_code = result_dict.get('errorCode', 0)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -30,8 +30,8 @@ from google._upb._message import RepeatedCompositeContainer
 from google.protobuf.json_format import MessageToDict
 from grpc import RpcError
 from grpc import StatusCode
-import kachaka_api
 from kachaka_api.generated import kachaka_api_pb2 as pb2
+from kachaka_client_with_keepalive import KachakaApiClientWithKeepalive
 import yaml
 import zenoh
 
@@ -52,6 +52,18 @@ class Pose:
 
 @dataclass(frozen=True)
 class CommandCompletion:
+    """Internal command completion state.
+
+    error_code values used internally:
+        0   : success
+        -1  : unknown / format error
+        -2  : map name mismatch
+        -3  : superseded by a new command
+        -4  : gRPC channel persistently stuck (Deadline Exceeded > grpc_stuck threshold)
+
+    Negative error_codes are internal signals to RMF for replan; not retriable on Kachaka side.
+    """
+
     task_id: str
     is_completed: bool
     success: Optional[bool]
@@ -172,6 +184,7 @@ class KachakaApiClientByZenoh:
         self.running_state_wait = timeouts.get('running_state_wait', 5.0)
         self.grpc_telemetry_timeout = timeouts.get('grpc_telemetry', 5.0)
         self.grpc_status_check_timeout = timeouts.get('grpc_status_check', 5.0)
+        self.grpc_stuck_threshold = float(timeouts.get('grpc_stuck', 30.0))
         self.command_check_interval = intervals.get('command_check', 4.0)
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
@@ -182,8 +195,9 @@ class KachakaApiClientByZenoh:
         self.max_navigation_retries = navigation_retry.get('max_retries', 3)
         self.retry_interval = navigation_retry.get('retry_interval', 2.0)
         self.retry_on_error_types = navigation_retry.get('retry_on_error_types', ['Error'])
-        self.kachaka_client = (kachaka_api.KachakaApiClient(kachaka_access_point)
-                               if kachaka_access_point else kachaka_api.KachakaApiClient())
+        self.kachaka_access_point = kachaka_access_point
+        self.kachaka_client = (KachakaApiClientWithKeepalive(kachaka_access_point)
+                               if kachaka_access_point else KachakaApiClientWithKeepalive())
         self.robot_name = robot_name
         self.task_id = None
         logging.basicConfig(
@@ -227,6 +241,8 @@ class KachakaApiClientByZenoh:
         self.async_command_started_at = None
         self.retry_count = 0
         self._command_lock = threading.RLock()
+        self._client_lock = threading.RLock()
+        self._first_grpc_failure_time: Optional[float] = None
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -502,6 +518,7 @@ class KachakaApiClientByZenoh:
                     return
 
                 state_res = self._get_command_state_response()
+                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
@@ -606,12 +623,47 @@ class KachakaApiClientByZenoh:
                     self._reset_async_command_state()
 
         except RpcError as e:
-            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+            code = e.code()
+            is_deadline = code == StatusCode.DEADLINE_EXCEEDED
+            is_unavailable = code == StatusCode.UNAVAILABLE
+            if is_deadline:
                 self.logger.warning(f'Timeout in {method_name}, publishing cached value')
+            elif is_unavailable:
+                self.logger.warning(f'UNAVAILABLE in {method_name}, will reconstruct client')
             else:
                 self._log_error('RPC', method_name, e)
-            if self.last_command_result:
-                self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+
+            fail_recovery_needed = False
+            immediate_reconnect_needed = False
+            with self._command_lock:
+                if is_unavailable:
+                    immediate_reconnect_needed = True
+                    self._first_grpc_failure_time = None
+                elif is_deadline and self.task_id:
+                    now = time.monotonic()
+                    if self._first_grpc_failure_time is None:
+                        self._first_grpc_failure_time = now
+                    elif now - self._first_grpc_failure_time >= self.grpc_stuck_threshold:
+                        stuck_task = self.task_id
+                        self._log_error_msg(f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
+                                            f'publishing failure (error_code=-4) and reconstructing client')
+                        fail_result = CommandCompletion(
+                            task_id=stuck_task,
+                            is_completed=True,
+                            success=False,
+                            error_code=-4,
+                        )
+                        self.last_command_result = fail_result
+                        self._publish_to_zenoh(self.command_is_completed_pub, fail_result.as_payload())
+                        self._reset_async_command_state()
+                        self._first_grpc_failure_time = None
+                        fail_recovery_needed = True
+
+                if not (fail_recovery_needed or immediate_reconnect_needed) and self.last_command_result:
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+
+            if fail_recovery_needed or immediate_reconnect_needed:
+                self._reconstruct_kachaka_client()
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -624,6 +676,10 @@ class KachakaApiClientByZenoh:
         Returns:
             bool: True if the command should be retried, False otherwise
         """
+        # Negative error codes are internal signals to RMF (replan); never retry on Kachaka side.
+        if error_code < 0:
+            self.logger.info(f'Internal error code {error_code}; not retriable on Kachaka side')
+            return False
         try:
             # error_code=0 with success=False typically means the navigation was cancelled
             # (e.g., due to temporary obstacles from LiDAR noise). This should be retried.
@@ -988,6 +1044,31 @@ class KachakaApiClientByZenoh:
         self.saw_running = False
         self.current_command_id = None
         self.async_command_started_at = None
+
+    def _reconstruct_kachaka_client(self) -> bool:
+        """Recreate the KachakaApiClient to recover from a dead gRPC channel.
+
+        Closes the old channel explicitly before creating a new one to
+        release resources promptly. In-flight RPCs hold the old client
+        through their local references, so swapping the attribute is safe.
+        """
+        with self._client_lock:
+            old_client = self.kachaka_client
+            try:
+                self._log_info('Reconstructing KachakaApiClient to recover gRPC channel')
+                new_client = (KachakaApiClientWithKeepalive(self.kachaka_access_point)
+                              if self.kachaka_access_point else KachakaApiClientWithKeepalive())
+                self.kachaka_client = new_client
+                self._log_info('KachakaApiClient reconstructed successfully')
+                try:
+                    if hasattr(old_client, 'close'):
+                        old_client.close()
+                except Exception as ce:
+                    self.logger.warning(f'Failed to close old client channel: {ce}')
+                return True
+            except Exception as e:
+                self._log_error('Unexpected', '_reconstruct_kachaka_client', e)
+                return False
 
     def _publish_command_completion(self, success: bool, error_code: int) -> bool:
         """Publish command completion status to Zenoh.

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -1002,16 +1002,28 @@ class KachakaApiClientByZenoh:
             method = getattr(self.kachaka_client, method_name)
             response = self._to_dict(method(**args))
 
-            # Check if response contains a 'result' field (synchronous commands return Result)
-            if isinstance(response, dict) and 'result' in response:
-                result = response['result']
-                success = result.get('success', False)
-                # Note: MessageToDict converts snake_case to camelCase
-                error_code = result.get('errorCode', 0)
+            # Extract the command Result. The kachaka high-level client's
+            # start_command() unwraps StartCommandResponse and returns the bare
+            # Result message, so async commands (move_to_pose, return_home)
+            # arrive as {'success': ..., 'errorCode': ...} with no nested
+            # 'result' key. Handle both the bare Result and the wrapped shape;
+            # MessageToDict converts snake_case to camelCase (error_code ->
+            # errorCode) and drops zero-valued fields.
+            result_dict: Optional[Dict[str, Any]] = None
+            if isinstance(response, dict):
+                if isinstance(response.get('result'), dict):
+                    result_dict = response['result']
+                elif 'success' in response:
+                    result_dict = response
+
+            if result_dict is not None:
+                success = result_dict.get('success', False)
+                error_code = result_dict.get('errorCode', 0)
 
                 if self.is_async_command and success:
-                    # Async command started, don't publish completion yet
-                    # publish_result will handle completion after RUNNING state is seen
+                    # Async command started, don't publish completion yet.
+                    # publish_result polls GetCommandState/GetLastCommandResult
+                    # and publishes completion after RUNNING state is seen.
                     self.async_command_started_at = time.monotonic()
                     self.logger.info(f'Async command {method_name} started')
                 elif success:
@@ -1023,7 +1035,7 @@ class KachakaApiClientByZenoh:
                     if publish_completion:
                         self._publish_command_completion(success=False, error_code=error_code)
             else:
-                # No result field (e.g., switch_map), assume success
+                # Response carries no success/result info; assume success.
                 self.logger.info(f'Command {method_name} executed successfully')
                 if publish_completion:
                     self._publish_command_completion(success=True, error_code=0)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -873,7 +873,10 @@ class KachakaApiClientByZenoh:
             # switch map only if the map is different from the current map id
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
-                self._command_context_map_name = args.get('map_name')
+                rmf_map_name = args.get('map_name')
+                self._command_context_map_name = rmf_map_name
+                self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
+                self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:

--- a/scripts/kachaka_client_with_keepalive.py
+++ b/scripts/kachaka_client_with_keepalive.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env pipenv-shebang
+# -*- encoding: utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import grpc
+import kachaka_api
+from kachaka_api.base import _resolve_target
+from kachaka_api.base import ShelfLocationResolver
+from kachaka_api.generated.kachaka_api_pb2_grpc import KachakaApiStub
+
+
+class KachakaApiClientWithKeepalive(kachaka_api.KachakaApiClient):
+    """KachakaApiClient with HTTP/2 keepalive enabled for half-open detection.
+
+    The upstream library opens an unconfigured grpc.insecure_channel, leaving
+    no protocol-level liveness check. A persistently unresponsive server then
+    keeps producing DEADLINE_EXCEEDED rather than UNAVAILABLE because the
+    client never realizes the channel is dead.
+
+    This subclass replaces parent initialization to own the channel directly,
+    enabling explicit close during reconstruction and HTTP/2 PINGs that mark
+    the channel BROKEN within keepalive_timeout_ms when ACKs stop arriving.
+    """
+
+    KEEPALIVE_OPTIONS = [
+        ('grpc.keepalive_time_ms', 30000),
+        ('grpc.keepalive_timeout_ms', 10000),
+        ('grpc.keepalive_permit_without_calls', 1),
+        ('grpc.http2.max_pings_without_data', 0),
+    ]
+
+    def __init__(self, target: str = '100.94.1.1:26400') -> None:
+        target_resolved = _resolve_target(target)
+        if target_resolved is None:
+            raise ValueError(f'Invalid target: {target}')
+        self._channel = grpc.insecure_channel(target_resolved, options=self.KEEPALIVE_OPTIONS)
+        self.stub = KachakaApiStub(self._channel)
+        self.resolver = ShelfLocationResolver()
+
+    def close(self) -> None:
+        """Close the underlying gRPC channel. Idempotent."""
+        try:
+            self._channel.close()
+        except Exception:
+            pass

--- a/scripts/rest_kachaka_api.py
+++ b/scripts/rest_kachaka_api.py
@@ -41,7 +41,7 @@ async def init_channel() -> None:
     """
     global kachaka_client
     kachaka_client = kachaka_api.aio.KachakaApiClient(
-        os.getenv("KACHAKA_ACCESS_POINT", "localhost:26400"))
+        os.getenv("KACHAKA_ACCESS_POINT", "100.94.1.1:26400"))
     await kachaka_client.update_resolver()
 
 

--- a/test/test_kachaka_client_with_keepalive.py
+++ b/test/test_kachaka_client_with_keepalive.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for KachakaApiClientWithKeepalive."""
+
+from pathlib import Path
+import sys
+
+import grpc
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+
+from kachaka_client_with_keepalive import KachakaApiClientWithKeepalive  # noqa: E402
+
+
+def test_keepalive_options_present() -> None:
+    """KEEPALIVE_OPTIONS includes the expected gRPC channel arguments."""
+    keys = {opt[0] for opt in KachakaApiClientWithKeepalive.KEEPALIVE_OPTIONS}
+    assert 'grpc.keepalive_time_ms' in keys
+    assert 'grpc.keepalive_timeout_ms' in keys
+    assert 'grpc.keepalive_permit_without_calls' in keys
+
+
+def test_init_creates_channel_and_stub() -> None:
+    """Constructor builds a channel that can be closed without errors."""
+    client = KachakaApiClientWithKeepalive('127.0.0.1:1')
+    channel = client._channel  # noqa: SLF001
+    assert channel is not None
+    assert isinstance(channel, grpc.Channel)
+    assert client.stub is not None
+    client.close()
+
+
+def test_close_is_idempotent() -> None:
+    """close() can be called multiple times without raising."""
+    client = KachakaApiClientWithKeepalive('127.0.0.1:1')
+    client.close()
+    client.close()
+
+
+def test_invalid_target_raises() -> None:
+    """An unresolvable target string surfaces as ValueError."""
+    with pytest.raises(ValueError):
+        KachakaApiClientWithKeepalive('not-a-valid-target-string')

--- a/test/test_map_state_guard.py
+++ b/test/test_map_state_guard.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the map guard and its self-healing re-sync behaviour.
+
+The robot's actual map (gRPC) is the single source of truth. The cached
+telemetry map name can go stale when a switch_map result is lost or the map
+is changed outside the bridge (e.g. from the smartphone app); these tests
+verify that the guard re-queries the robot instead of trusting the cache.
+"""
+# ruff: noqa: SLF001
+
+import logging
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from typing import List, Optional
+from unittest.mock import MagicMock
+
+import grpc
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+
+from connect_openrmf_by_zenoh import KachakaApiClientByZenoh  # noqa: E402
+from connect_openrmf_by_zenoh import MapState  # noqa: E402
+from connect_openrmf_by_zenoh import Pose  # noqa: E402
+
+
+class FakeRpcError(grpc.RpcError):
+    """Minimal RpcError stand-in with the attributes the bridge reads."""
+
+    def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.DEADLINE_EXCEEDED
+
+    def details(self) -> str:
+        return 'Deadline Exceeded'
+
+
+def make_node(
+    telemetry_map_name: str,
+    robot_map_name: Optional[str] = None,
+    grpc_error: bool = False,
+) -> KachakaApiClientByZenoh:
+    """Build a KachakaApiClientByZenoh without running __init__.
+
+    Args:
+        telemetry_map_name: The cached (possibly stale) map name.
+        robot_map_name: The Kachaka-side name of the map the robot actually
+            reports via gRPC. Ignored when grpc_error is True.
+        grpc_error: If True, all gRPC stub calls raise FakeRpcError.
+
+    Returns:
+        A node instance with mocked gRPC stub and Zenoh publishers.
+    """
+    node = object.__new__(KachakaApiClientByZenoh)
+    node.logger = logging.getLogger('test_map_state_guard')
+    node.robot_name = 'test_robot'
+    node.map_state = MapState.initial().with_telemetry_map_name(telemetry_map_name)
+    # Kachaka-side names L8/L12 map to RMF-side names 8F/12F
+    node.reverse_map_name_mapping = {'L8': '8F', 'L12': '12F'}
+    node.map_name_mapping = {'8F': 'L8', '12F': 'L12'}
+    node.grpc_status_check_timeout = 0.1
+    node.grpc_telemetry_timeout = 0.1
+    node.last_pose = Pose.zero()
+    node.map_name_pub = MagicMock()
+    node.pose_pub = MagicMock()
+    node._publish_to_zenoh = MagicMock(return_value=True)
+    node._publish_command_completion = MagicMock(return_value=True)
+
+    stub = MagicMock()
+    if grpc_error:
+        stub.GetMapList.side_effect = FakeRpcError()
+        stub.GetCurrentMapId.side_effect = FakeRpcError()
+        stub.GetRobotPose.side_effect = FakeRpcError()
+    else:
+        entries = [
+            SimpleNamespace(id='map-id-8f', name='L8'),
+            SimpleNamespace(id='map-id-12f', name='L12'),
+        ]
+        current_id = next(e.id for e in entries if e.name == robot_map_name)
+        stub.GetMapList.return_value = SimpleNamespace(map_list_entries=entries)
+        stub.GetCurrentMapId.return_value = SimpleNamespace(id=current_id)
+        stub.GetRobotPose.return_value = SimpleNamespace(pose=SimpleNamespace(x=1.0, y=2.0, theta=0.5))
+    node.kachaka_client = MagicMock()
+    node.kachaka_client.stub = stub
+    return node
+
+
+def published_completions(node: KachakaApiClientByZenoh) -> List[dict]:
+    """Return the kwargs of all _publish_command_completion calls."""
+    return [call.kwargs for call in node._publish_command_completion.call_args_list]
+
+
+def test_guard_passes_without_grpc_when_cache_matches() -> None:
+    """No re-query happens when the requested map matches the cache."""
+    node = make_node(telemetry_map_name='8F', robot_map_name='L8')
+    assert node._verify_map_for_navigation('8F') is True
+    node.kachaka_client.stub.GetCurrentMapId.assert_not_called()
+    node._publish_command_completion.assert_not_called()
+
+
+def test_guard_self_heals_when_cache_is_stale() -> None:
+    """A stale cache (12F) is corrected from the robot (8F) and navigation proceeds.
+
+    This is the incident scenario: the robot is actually on the requested
+    floor but the cached map name was left on the previous floor.
+    """
+    node = make_node(telemetry_map_name='12F', robot_map_name='L8')
+    assert node._verify_map_for_navigation('8F') is True
+    assert node.map_state.telemetry_map_name == '8F'
+    node._publish_command_completion.assert_not_called()
+    # The corrected map name is published so RMF stays consistent
+    node._publish_to_zenoh.assert_called_once_with(node.map_name_pub, '8F')
+
+
+def test_guard_rejects_genuine_mismatch() -> None:
+    """Navigation is rejected when the robot really is on a different map."""
+    node = make_node(telemetry_map_name='8F', robot_map_name='L12')
+    assert node._verify_map_for_navigation('12F') is True  # sanity: robot is on 12F
+    node = make_node(telemetry_map_name='12F', robot_map_name='L12')
+    assert node._verify_map_for_navigation('8F') is False
+    assert published_completions(node) == [{'success': False, 'error_code': -2}]
+
+
+def test_guard_rejects_when_robot_unreachable() -> None:
+    """Navigation is rejected (not allowed through) when gRPC fails."""
+    node = make_node(telemetry_map_name='12F', grpc_error=True)
+    assert node._verify_map_for_navigation('8F') is False
+    assert published_completions(node) == [{'success': False, 'error_code': -2}]
+    # Cache must not be corrupted on failure
+    assert node.map_state.telemetry_map_name == '12F'
+
+
+def test_recover_interrupted_switch_map_success() -> None:
+    """A lost switch_map response is completed as success when the robot switched."""
+    node = make_node(telemetry_map_name='12F', robot_map_name='L8')
+    recovered = node._recover_interrupted_switch_map({'map_name': '8F', 'pose': {'x': 1.0, 'y': 2.0, 'theta': 0.5}})
+    assert recovered is True
+    assert node.map_state.telemetry_map_name == '8F'
+    assert node.last_pose.as_list() == [1.0, 2.0, 0.5]
+    assert published_completions(node) == [{'success': True, 'error_code': 0}]
+
+
+def test_recover_interrupted_switch_map_not_switched() -> None:
+    """No recovery happens when the robot never switched; caller reports failure."""
+    node = make_node(telemetry_map_name='12F', robot_map_name='L12')
+    assert node._recover_interrupted_switch_map({'map_name': '8F'}) is False
+    node._publish_command_completion.assert_not_called()
+    assert node.map_state.telemetry_map_name == '12F'
+
+
+def test_recover_interrupted_switch_map_grpc_failure() -> None:
+    """No recovery happens when the robot cannot be queried."""
+    node = make_node(telemetry_map_name='12F', grpc_error=True)
+    assert node._recover_interrupted_switch_map({'map_name': '8F'}) is False
+    node._publish_command_completion.assert_not_called()


### PR DESCRIPTION
## 概要

コマンド完了処理、フロア遷移時のレース条件、gRPC 応答停止からの自動復旧を1本に統合した PR。

- fix #23 — publish_result と _execute_command 間のスレッドセーフティ問題
- fix #33 — switch_map 完了レース条件によるフロア遷移後の map mismatch
- fix #34 — gRPC half-open 検知不能による navigation コマンドの応答停止
- fix #42 — switch_map 完了直後の (新map_name, 旧pose) race による fleet_adapter の "too far" replan 誤発火

旧 PR #25, #30, #31 を本 PR に統合。

## 含まれる修正（3領域）

### 1. コマンド完了処理の不整合修正（旧 PR #25）-> Merge済

- command_id ベースの非同期コマンド追跡（move_to_pose, return_home）
- RLock によるスレッド安全性（publish_result / _execute_command 間）
- ナビゲーション失敗時の自動リトライ（設定可能）
- 新コマンドで上書きされた旧タスクの supersede 処理（error_code=-3）
- テレメトリ gRPC 呼び出しに 5s デッドライン追加（EV 中のメインループ凍結防止）
- Pose・完了通知・フロア状態の dataclass モデル化
- `_command_context_map_name` をテレメトリから初期化（ハードコード 'L1' を廃止）
- `_command_context_map_name` をコマンドスレッド専用に分離（テレメトリスレッドとの lost-update race 解消）

### 2. switch_map 完了レース条件対策（旧 PR #30）->レビュー済

- switch_map 成功後、map_name を Zenoh に publish してから completion を通知（順序保証）
- switch_map 成功後、localize 目標 pose も Zenoh に publish してから completion を通知（map_name と pose を整合ペアで先出し、fix #42）
- リトライの task_id ガード（sleep 中にコマンドが切り替わっても旧タスクのリトライが新タスクに伝播しない）
- switch_map が no-op（同一フロア）のケースでも map_name/map_state を publish

### 3. gRPC half-open 検知と自動復旧（旧 PR #31）

- `KachakaApiClientWithKeepalive`: HTTP/2 PING keepalive (30s/10s) で half-open を UNAVAILABLE 化
- UNAVAILABLE 受信で即時 client 再構築
- Deadline Exceeded が 30s 超持続で `is_completed=True` publish → RMF アンブロック → client 再構築
- `kachaka_startup.sh`: REST API opt-out（`DISABLE_REST_API=1`）、プロセス終了処理改善
- `rest_kachaka_api.py` デフォルトアドレスを `100.94.1.1:26400` に統一

## 動作検証手順

### 前提
- Kachaka 実機 + 本ブランチの bridge を起動
- Zenoh router 経由で `test/test_kachaka_command.py` からコマンド送信

### 基本動作
```bash
# 同一フロア move_to_pose
python test/test_kachaka_command.py <zenoh_router> <robot_name> move_to_pose 1.0 2.0 0.0

# dock (return_home)
python test/test_kachaka_command.py <zenoh_router> <robot_name> dock

# コマンド上書き（supersede）→ ターミナルAに error_code: -3
# ターミナルA: 遠い目的地
python test/test_kachaka_command.py <zenoh_router> <robot_name> move_to_pose 10.0 0.0 0.0
# 移動開始後、ターミナルB: 別コマンド
python test/test_kachaka_command.py <zenoh_router> <robot_name> move_to_pose -1.0 0.0 0.0
```

### #33 確認（switch_map レース）
- [ ] 異フロア switch_map → 直後 move_to_pose が reject されずに RUNNING に入る
- [ ] 同フロア switch_map (no-op) でも Zenoh 上の map_name が publish される
- [ ] リフト乗降を含む配送タスクで初回 move_to_pose が成功する

### #34 確認（gRPC stuck）
- [ ] 通常 navigation が完了通知まで正常動作する
- [ ] gRPC 応答停止時に 30s 以内で stuck 検知 → `is_completed=True` publish → client 再構築

### 回帰確認
- [ ] move_to_pose / dock / return_home が従来通り完走
- [ ] navigation retry が retriable error で動作
- [ ] `DISABLE_REST_API=1` で uvicorn が起動しない
- [ ] bridge を kill → kachaka_startup.sh が exit

## テスト

- [x] yapf / ruff / pre-commit hooks: clean
- [x] `test/test_kachaka_client_with_keepalive.py`: 4/4 pass
- [x] Toxiproxy keepalive 効果検証（詳細は旧 PR #31 参照）
- [x] 23.5h 実機連続 soak: GOAWAY/UNAVAILABLE/Reconstructing 累計 0 件

Generated with [Claude Code](https://claude.ai/code)
