### PR TITLE
test: add regression tests for command completion lifecycle

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,6 +17,7 @@ timeouts:
   running_state_wait: 5.0   # Max wait time for RUNNING state after command sent
   grpc_telemetry: 5.0       # Timeout for telemetry gRPC calls (get_robot_pose, etc.)
   grpc_status_check: 5.0    # Timeout for command status gRPC calls (GetCommandState, etc.)
+  grpc_stuck: 30.0          # Threshold (sec) for treating persistent Deadline Exceeded as a stuck channel
 
 intervals:
   command_check: 4.0        # How often to check for new commands

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -22,7 +22,7 @@ if ! nc -z -w $timeout $KACHAKA_IP $SSH_PORT; then
     echo "See https://github.com/pf-robotics/kachaka-api?tab=readme-ov-file#playground%E3%81%ABssh%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%99%E3%82%8B"
     exit 1
 fi
-RUN_LINE="jupyter-lab --port=26501 --ip='0.0.0.0' & uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502"
+RUN_ZENOH=""
 # Ask whether to set up Zenoh client. If yes, ask the router access point and the robot name.
 read -p "Do you want to set up the Zenoh client? (y/n) " -n 1 -r
 echo
@@ -31,9 +31,12 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
   read -p "Enter the robot name: " ROBOT_NAME
   read -p "Enter log level (DEBUG/INFO/WARNING/ERROR/CRITICAL) [INFO]: " LOG_LEVEL
   LOG_LEVEL=${LOG_LEVEL:-INFO}
-  RUN_LINE="$RUN_LINE & python3 sbgisen/connect_openrmf_by_zenoh.py"
+  RUN_ZENOH=1
 fi
-# Create the server setup script with dynamic KACHAKA_IP
+# Create the server setup script with dynamic KACHAKA_IP.
+# REST API (uvicorn) is launched by default; set DISABLE_REST_API=1 in the
+# Kachaka environment to skip it (useful for OpenRMF-only deployments and
+# for diagnosing gRPC server load issues).
 cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
@@ -46,7 +49,12 @@ export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export LOG_LEVEL=$LOG_LEVEL
 export PATH=/home/kachaka/.local/bin:\$PATH
-$RUN_LINE
+jupyter-lab --port=26501 --ip='0.0.0.0' &
+if [ "\${DISABLE_REST_API:-0}" != "1" ]; then
+  uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502 &
+fi
+${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
+wait
 EOF
 
 ssh -p $SSH_PORT kachaka@$KACHAKA_IP <<EOF

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -41,10 +41,6 @@ cat <<EOF > kachaka_startup.sh
 #!/bin/bash
 # LINES MODIFIED BY SBGISEN, SEE /home/kachaka/kachaka_startup.sh.backup FOR THE ORIGINAL FILE.
 export KACHAKA_IP=$KACHAKA_IP
-# When running on the Kachaka robot internally, KACHAKA_ACCESS_POINT is optional
-if [ -n "$KACHAKA_IP" ]; then
-  export KACHAKA_ACCESS_POINT=\$KACHAKA_IP:26400
-fi
 export ZENOH_ROUTER_ACCESS_POINT=$ZENOH_ROUTER_ACCESS_POINT
 export ROBOT_NAME=$ROBOT_NAME
 export LOG_LEVEL=$LOG_LEVEL

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -56,7 +56,9 @@ fi
 ${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
 # Exit when any child process dies so the supervisor can restart the whole stack
 # (matches the original foreground-bridge behaviour where bridge death exited the script).
-trap 'kill 0' EXIT
+# Use jobs -p to limit the cleanup to processes this script started; kill 0 would
+# also signal the parent shell or unrelated members of the same process group.
+trap 'jobs -p | xargs -r kill 2>/dev/null' EXIT
 wait -n
 EOF
 

--- a/kachaka_server_setup.sh
+++ b/kachaka_server_setup.sh
@@ -54,7 +54,10 @@ if [ "\${DISABLE_REST_API:-0}" != "1" ]; then
   uvicorn sbgisen.rest_kachaka_api:app --host 0.0.0.0 --port 26502 &
 fi
 ${RUN_ZENOH:+python3 sbgisen/connect_openrmf_by_zenoh.py &}
-wait
+# Exit when any child process dies so the supervisor can restart the whole stack
+# (matches the original foreground-bridge behaviour where bridge death exited the script).
+trap 'kill 0' EXIT
+wait -n
 EOF
 
 ssh -p $SSH_PORT kachaka@$KACHAKA_IP <<EOF

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -854,19 +854,27 @@ class KachakaApiClientByZenoh:
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:
-                response = self._execute_sync_method('switch_map', payload)
-                # Update command context if switch_map did not raise an exception.
-                # Note: switch_map response may lack 'result' field, so we check
-                # both formats: with result.success and without result (assume success).
+                # Suppress automatic completion in _execute_sync_method so we can
+                # publish map_name to Zenoh *before* notifying RMF of completion.
+                # This prevents a race where RMF receives the completion, queries
+                # the robot's map_name (still the old floor), and issues a
+                # navigation command with stale floor coordinates.
+                response = self._execute_sync_method('switch_map', payload, publish_completion=False)
                 success = True
                 if response and isinstance(response, dict) and 'result' in response:
                     success = response['result'].get('success', False)
                 if success:
-                    self._command_context_map_name = args.get('map_name')
+                    rmf_map_name = args.get('map_name')
+                    self._command_context_map_name = rmf_map_name
+                    self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
+                    self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                     self.logger.info(
-                        'Updated command_context_map_name after successful switch_map: %s',
-                        self._command_context_map_name,
+                        'Published map_name=%s to Zenoh after successful switch_map',
+                        rmf_map_name,
                     )
+                    self._publish_command_completion(success=True, error_code=0)
+                else:
+                    self._publish_command_completion(success=False, error_code=-1)
         except RpcError as e:
             self._log_error('RPC', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
@@ -874,12 +882,20 @@ class KachakaApiClientByZenoh:
             self._log_error('Unexpected', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
 
-    def _execute_sync_method(self, method_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
-        """Execute a method synchronously and publish completion status.
+    def _execute_sync_method(
+        self,
+        method_name: str,
+        args: Dict[str, Any],
+        publish_completion: bool = True,
+    ) -> Dict[str, Any]:
+        """Execute a method synchronously and optionally publish completion status.
 
         Args:
             method_name (str): The name of the method to execute
             args (Dict[str, Any]): The arguments for the method
+            publish_completion (bool): Whether to automatically publish completion
+                status. Set to False when the caller needs to perform additional
+                state updates (e.g., publishing map_name) before notifying RMF.
 
         Returns:
             Dict[str, Any]: The response from the method
@@ -888,7 +904,7 @@ class KachakaApiClientByZenoh:
             if not self.grpc_connection_check():
                 error_msg = f'Failed to connect to Kachaka API server for method {method_name}'
                 self.logger.error(error_msg)
-                if self.task_id:
+                if self.task_id and publish_completion:
                     self._publish_command_completion(success=False, error_code=-1)
                 raise ConnectionError(error_msg)
 
@@ -909,16 +925,17 @@ class KachakaApiClientByZenoh:
                     self.logger.info(f'Async command {method_name} started')
                 elif success:
                     self.logger.info(f'Command {method_name} completed successfully')
-                    # Synchronous command completed successfully
-                    self._publish_command_completion(success=True, error_code=0)
+                    if publish_completion:
+                        self._publish_command_completion(success=True, error_code=0)
                 else:
                     self._log_warning(f'Command {method_name} failed with error_code={error_code}')
-                    # Always publish failure immediately
-                    self._publish_command_completion(success=False, error_code=error_code)
+                    if publish_completion:
+                        self._publish_command_completion(success=False, error_code=error_code)
             else:
                 # No result field (e.g., switch_map), assume success
                 self.logger.info(f'Command {method_name} executed successfully')
-                self._publish_command_completion(success=True, error_code=0)
+                if publish_completion:
+                    self._publish_command_completion(success=True, error_code=0)
 
             return response
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -984,11 +984,14 @@ class KachakaApiClientByZenoh:
 
         MessageToDict drops zero-valued fields, so a plain success serializes
         to {'success': True} and a failure with a non-zero code to
-        {'errorCode': N}. A Result with success=False and error_code=0
+        {'errorCode': N}. A bare Result with success=False and error_code=0
         therefore serializes to {} and is indistinguishable from a response
-        that carries no Result at all; both yield None (callers treat None as
-        success). This edge does not occur for the dispatch-time results
-        handled here, where failures always carry a non-zero error code.
+        that carries no Result at all; both yield None and callers treat None
+        as success. (The wrapped {'result': {...}} branch instead returns the
+        nested dict verbatim, so an empty {'result': {}} yields {} and is read
+        as success=False.) This ambiguous bare case does not occur for the
+        dispatch-time results handled here, where failures always carry a
+        non-zero error code.
         """
         if not isinstance(response, dict):
             return None

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -958,8 +958,14 @@ class KachakaApiClientByZenoh:
                     self._command_context_map_name = rmf_map_name
                     self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
                     self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
+                    # Pose must precede completion: RMF reading (new map_name, stale pose) triggers "too far" replan.
+                    target_pose = payload['pose']
+                    new_pose = Pose(target_pose.get('x', 0.0), target_pose.get('y', 0.0),
+                                    target_pose.get('theta', 0.0))
+                    self.last_pose = new_pose
+                    self._publish_to_zenoh(self.pose_pub, new_pose.as_list())
                     self.logger.info(
-                        'Published map_name=%s to Zenoh after successful switch_map',
+                        'Published map_name=%s and target pose to Zenoh after successful switch_map',
                         rmf_map_name,
                     )
                     self._publish_command_completion(success=True, error_code=0)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -54,10 +54,9 @@ class Pose:
 class CommandCompletion:
     """Internal command completion state.
 
-    success and error_code are kept on the instance for the Kachaka-side retry
-    logic but are NOT published over Zenoh — see as_payload(). The signal that
-    actually reaches RMF is is_completed; flipping it to True for an active
-    task is what unblocks RMF from a stuck-running state.
+    as_payload() publishes {id, is_completed, success} to Zenoh.
+    error_code is kept on the instance for the Kachaka-side retry logic
+    but is NOT published — see as_payload().
 
     error_code values used internally (not transmitted):
         0   : success
@@ -81,13 +80,15 @@ class CommandCompletion:
     def as_payload(self) -> Dict[str, Any]:
         """Return the payload for Zenoh publishing.
 
-        Only includes fields that consumers (fleet_adapter, lci_lift_request_converter) use.
-        success/error_code are internal state for retry logic and not published.
+        error_code is internal state for retry logic and not published.
         """
-        return {
+        payload: Dict[str, Any] = {
             'id': self.task_id,
             'is_completed': self.is_completed,
         }
+        if self.is_completed and self.success is not None:
+            payload['success'] = self.success
+        return payload
 
 
 @dataclass(frozen=True)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -439,33 +439,46 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
-    async def _handle_command_retry(self, error_code: int) -> bool:
+    async def _handle_command_retry(self, task_id: str, error_code: int) -> bool:
         """Handle retry logic for failed commands.
 
         Args:
+            task_id: The task ID that produced the failed result
             error_code: The error code from the failed command
 
         Returns:
             True if retry was initiated (caller should return early), False otherwise
         """
-        if not self.retry_enabled or self.retry_count >= self.max_navigation_retries:
-            if self.retry_count >= self.max_navigation_retries:
-                self._log_error_msg(f'Max retries ({self.max_navigation_retries}) exceeded for command {self.task_id}')
-            return False
-
         should_retry = await self._should_retry_command(error_code)
         if not should_retry:
             self._log_info(f'Error code {error_code} is not retriable')
             return False
 
-        self.retry_count += 1
-        self._log_info(f'Retrying command (attempt {self.retry_count}/{self.max_navigation_retries})')
+        with self._command_lock:
+            if self.task_id != task_id:
+                self.logger.debug('Skip retry for stale task %s (active task: %s)', task_id, self.task_id)
+                return False
+            if not self.retry_enabled or self.retry_count >= self.max_navigation_retries:
+                if self.retry_count >= self.max_navigation_retries:
+                    self._log_error_msg(f'Max retries ({self.max_navigation_retries}) exceeded for command {task_id}')
+                return False
+            if not self.last_command:
+                return False
+
+            self.retry_count += 1
+            retry_count = self.retry_count
+            command_to_retry = self.last_command.copy()
+
+        self._log_info(f'Retrying command (attempt {retry_count}/{self.max_navigation_retries})')
 
         await asyncio.sleep(self.retry_interval)
-        if self.last_command:
-            self._execute_command(self.last_command)
-            return True
-        return False
+        with self._command_lock:
+            if self.task_id != task_id:
+                self.logger.debug('Cancel retry for stale task %s (active task: %s)', task_id, self.task_id)
+                return False
+
+        self._execute_command(command_to_retry)
+        return True
 
     async def publish_result(self) -> None:
         """Publish command completion status to Zenoh.
@@ -474,6 +487,8 @@ class KachakaApiClientByZenoh:
         Uses command_id to ensure state/result pairs belong to the active command.
         """
         method_name = 'publish_result'
+        retry_task_id: Optional[str] = None
+        retry_error_code: Optional[int] = None
         try:
             with self._command_lock:
                 if not self.task_id:
@@ -574,8 +589,16 @@ class KachakaApiClientByZenoh:
                         self.retry_count = 0
                     else:
                         self._log_warning(f'Command {self.task_id} failed with error code {error_code}')
-                        if await self._handle_command_retry(error_code):
-                            return  # Retry initiated, don't publish yet
+                        retry_task_id = self.task_id
+                        retry_error_code = error_code
+
+            if retry_task_id is not None and retry_error_code is not None:
+                if await self._handle_command_retry(retry_task_id, retry_error_code):
+                    return  # Retry initiated, don't publish yet
+
+            with self._command_lock:
+                if retry_task_id is not None and self.task_id != retry_task_id:
+                    return
 
                 # Publish and reset
                 self.last_command_result = result

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -54,14 +54,17 @@ class Pose:
 class CommandCompletion:
     """Internal command completion state.
 
-    error_code values used internally:
+    success and error_code are kept on the instance for the Kachaka-side retry
+    logic but are NOT published over Zenoh — see as_payload(). The signal that
+    actually reaches RMF is is_completed; flipping it to True for an active
+    task is what unblocks RMF from a stuck-running state.
+
+    error_code values used internally (not transmitted):
         0   : success
         -1  : unknown / format error
         -2  : map name mismatch
         -3  : superseded by a new command
         -4  : gRPC channel persistently stuck (Deadline Exceeded > grpc_stuck threshold)
-
-    Negative error_codes are internal signals to RMF for replan; not retriable on Kachaka side.
     """
 
     task_id: str
@@ -518,7 +521,6 @@ class KachakaApiClientByZenoh:
                     return
 
                 state_res = self._get_command_state_response()
-                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
@@ -564,6 +566,8 @@ class KachakaApiClientByZenoh:
                         return
 
                 last_result = self._get_last_command_result_response()
+                # Both GetCommandState and GetLastCommandResult succeeded; reset stuck timer.
+                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetLastCommandResult response: {last_result}')
                 result_command_id = last_result.get('commandId')
 
@@ -645,8 +649,12 @@ class KachakaApiClientByZenoh:
                         self._first_grpc_failure_time = now
                     elif now - self._first_grpc_failure_time >= self.grpc_stuck_threshold:
                         stuck_task = self.task_id
-                        self._log_error_msg(f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
-                                            f'publishing failure (error_code=-4) and reconstructing client')
+                        self._log_error_msg(
+                            f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
+                            f'publishing is_completed=True (internal error_code=-4) and reconstructing client')
+                        # error_code=-4 is internal-only; CommandCompletion.as_payload() drops it.
+                        # The signal that reaches RMF is is_completed=True, which unblocks the
+                        # adapter from treating the task as still running.
                         fail_result = CommandCompletion(
                             task_id=stuck_task,
                             is_completed=True,

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -951,9 +951,8 @@ class KachakaApiClientByZenoh:
                 # the robot's map_name (still the old floor), and issues a
                 # navigation command with stale floor coordinates.
                 response = self._execute_sync_method('switch_map', payload, publish_completion=False)
-                success = True
-                if response and isinstance(response, dict) and 'result' in response:
-                    success = response['result'].get('success', False)
+                result_dict = self._extract_command_result(response)
+                success = result_dict.get('success', False) if result_dict is not None else True
                 if success:
                     rmf_map_name = args.get('map_name')
                     self._command_context_map_name = rmf_map_name
@@ -972,6 +971,32 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
             self._publish_command_completion(success=False, error_code=-1)
+
+    @staticmethod
+    def _extract_command_result(response: Any) -> Optional[Dict[str, Any]]:  # noqa: ANN401
+        """Return the command Result dict from a method response, or None.
+
+        The kachaka high-level client's start_command() unwraps
+        StartCommandResponse and returns the bare Result message, so async
+        commands (move_to_pose, return_home) and switch_map arrive as
+        {'success': ..., 'errorCode': ...} with no nested 'result' key. The
+        wrapped {'result': {...}} shape is also accepted for safety.
+
+        MessageToDict drops zero-valued fields, so a plain success serializes
+        to {'success': True} and a failure with a non-zero code to
+        {'errorCode': N}. A Result with success=False and error_code=0
+        therefore serializes to {} and is indistinguishable from a response
+        that carries no Result at all; both yield None (callers treat None as
+        success). This edge does not occur for the dispatch-time results
+        handled here, where failures always carry a non-zero error code.
+        """
+        if not isinstance(response, dict):
+            return None
+        if isinstance(response.get('result'), dict):
+            return response['result']
+        if 'success' in response or 'errorCode' in response:
+            return response
+        return None
 
     def _execute_sync_method(
         self,
@@ -1002,20 +1027,7 @@ class KachakaApiClientByZenoh:
             method = getattr(self.kachaka_client, method_name)
             response = self._to_dict(method(**args))
 
-            # Extract the command Result. The kachaka high-level client's
-            # start_command() unwraps StartCommandResponse and returns the bare
-            # Result message, so async commands (move_to_pose, return_home)
-            # arrive as {'success': ..., 'errorCode': ...} with no nested
-            # 'result' key. Handle both the bare Result and the wrapped shape;
-            # MessageToDict converts snake_case to camelCase (error_code ->
-            # errorCode) and drops zero-valued fields.
-            result_dict: Optional[Dict[str, Any]] = None
-            if isinstance(response, dict):
-                if isinstance(response.get('result'), dict):
-                    result_dict = response['result']
-                elif 'success' in response:
-                    result_dict = response
-
+            result_dict = self._extract_command_result(response)
             if result_dict is not None:
                 success = result_dict.get('success', False)
                 error_code = result_dict.get('errorCode', 0)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -30,8 +30,8 @@ from google._upb._message import RepeatedCompositeContainer
 from google.protobuf.json_format import MessageToDict
 from grpc import RpcError
 from grpc import StatusCode
-import kachaka_api
 from kachaka_api.generated import kachaka_api_pb2 as pb2
+from kachaka_client_with_keepalive import KachakaApiClientWithKeepalive
 import yaml
 import zenoh
 
@@ -52,6 +52,18 @@ class Pose:
 
 @dataclass(frozen=True)
 class CommandCompletion:
+    """Internal command completion state.
+
+    error_code values used internally:
+        0   : success
+        -1  : unknown / format error
+        -2  : map name mismatch
+        -3  : superseded by a new command
+        -4  : gRPC channel persistently stuck (Deadline Exceeded > grpc_stuck threshold)
+
+    Negative error_codes are internal signals to RMF for replan; not retriable on Kachaka side.
+    """
+
     task_id: str
     is_completed: bool
     success: Optional[bool]
@@ -172,6 +184,7 @@ class KachakaApiClientByZenoh:
         self.running_state_wait = timeouts.get('running_state_wait', 5.0)
         self.grpc_telemetry_timeout = timeouts.get('grpc_telemetry', 5.0)
         self.grpc_status_check_timeout = timeouts.get('grpc_status_check', 5.0)
+        self.grpc_stuck_threshold = float(timeouts.get('grpc_stuck', 30.0))
         self.command_check_interval = intervals.get('command_check', 4.0)
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
@@ -182,8 +195,9 @@ class KachakaApiClientByZenoh:
         self.max_navigation_retries = navigation_retry.get('max_retries', 3)
         self.retry_interval = navigation_retry.get('retry_interval', 2.0)
         self.retry_on_error_types = navigation_retry.get('retry_on_error_types', ['Error'])
-        self.kachaka_client = (kachaka_api.KachakaApiClient(kachaka_access_point)
-                               if kachaka_access_point else kachaka_api.KachakaApiClient())
+        self.kachaka_access_point = kachaka_access_point
+        self.kachaka_client = (KachakaApiClientWithKeepalive(kachaka_access_point)
+                               if kachaka_access_point else KachakaApiClientWithKeepalive())
         self.robot_name = robot_name
         self.task_id = None
         logging.basicConfig(
@@ -227,6 +241,8 @@ class KachakaApiClientByZenoh:
         self.async_command_started_at = None
         self.retry_count = 0
         self._command_lock = threading.RLock()
+        self._client_lock = threading.RLock()
+        self._first_grpc_failure_time: Optional[float] = None
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -502,6 +518,7 @@ class KachakaApiClientByZenoh:
                     return
 
                 state_res = self._get_command_state_response()
+                self._first_grpc_failure_time = None
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
@@ -606,12 +623,47 @@ class KachakaApiClientByZenoh:
                     self._reset_async_command_state()
 
         except RpcError as e:
-            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+            code = e.code()
+            is_deadline = code == StatusCode.DEADLINE_EXCEEDED
+            is_unavailable = code == StatusCode.UNAVAILABLE
+            if is_deadline:
                 self.logger.warning(f'Timeout in {method_name}, publishing cached value')
+            elif is_unavailable:
+                self.logger.warning(f'UNAVAILABLE in {method_name}, will reconstruct client')
             else:
                 self._log_error('RPC', method_name, e)
-            if self.last_command_result:
-                self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+
+            fail_recovery_needed = False
+            immediate_reconnect_needed = False
+            with self._command_lock:
+                if is_unavailable:
+                    immediate_reconnect_needed = True
+                    self._first_grpc_failure_time = None
+                elif is_deadline and self.task_id:
+                    now = time.monotonic()
+                    if self._first_grpc_failure_time is None:
+                        self._first_grpc_failure_time = now
+                    elif now - self._first_grpc_failure_time >= self.grpc_stuck_threshold:
+                        stuck_task = self.task_id
+                        self._log_error_msg(f'gRPC stuck for {self.grpc_stuck_threshold}s on task {stuck_task}; '
+                                            f'publishing failure (error_code=-4) and reconstructing client')
+                        fail_result = CommandCompletion(
+                            task_id=stuck_task,
+                            is_completed=True,
+                            success=False,
+                            error_code=-4,
+                        )
+                        self.last_command_result = fail_result
+                        self._publish_to_zenoh(self.command_is_completed_pub, fail_result.as_payload())
+                        self._reset_async_command_state()
+                        self._first_grpc_failure_time = None
+                        fail_recovery_needed = True
+
+                if not (fail_recovery_needed or immediate_reconnect_needed) and self.last_command_result:
+                    self._publish_to_zenoh(self.command_is_completed_pub, self.last_command_result.as_payload())
+
+            if fail_recovery_needed or immediate_reconnect_needed:
+                self._reconstruct_kachaka_client()
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
@@ -624,6 +676,10 @@ class KachakaApiClientByZenoh:
         Returns:
             bool: True if the command should be retried, False otherwise
         """
+        # Negative error codes are internal signals to RMF (replan); never retry on Kachaka side.
+        if error_code < 0:
+            self.logger.info(f'Internal error code {error_code}; not retriable on Kachaka side')
+            return False
         try:
             # error_code=0 with success=False typically means the navigation was cancelled
             # (e.g., due to temporary obstacles from LiDAR noise). This should be retried.
@@ -988,6 +1044,31 @@ class KachakaApiClientByZenoh:
         self.saw_running = False
         self.current_command_id = None
         self.async_command_started_at = None
+
+    def _reconstruct_kachaka_client(self) -> bool:
+        """Recreate the KachakaApiClient to recover from a dead gRPC channel.
+
+        Closes the old channel explicitly before creating a new one to
+        release resources promptly. In-flight RPCs hold the old client
+        through their local references, so swapping the attribute is safe.
+        """
+        with self._client_lock:
+            old_client = self.kachaka_client
+            try:
+                self._log_info('Reconstructing KachakaApiClient to recover gRPC channel')
+                new_client = (KachakaApiClientWithKeepalive(self.kachaka_access_point)
+                              if self.kachaka_access_point else KachakaApiClientWithKeepalive())
+                self.kachaka_client = new_client
+                self._log_info('KachakaApiClient reconstructed successfully')
+                try:
+                    if hasattr(old_client, 'close'):
+                        old_client.close()
+                except Exception as ce:
+                    self.logger.warning(f'Failed to close old client channel: {ce}')
+                return True
+            except Exception as e:
+                self._log_error('Unexpected', '_reconstruct_kachaka_client', e)
+                return False
 
     def _publish_command_completion(self, success: bool, error_code: int) -> bool:
         """Publish command completion status to Zenoh.

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -1002,16 +1002,28 @@ class KachakaApiClientByZenoh:
             method = getattr(self.kachaka_client, method_name)
             response = self._to_dict(method(**args))
 
-            # Check if response contains a 'result' field (synchronous commands return Result)
-            if isinstance(response, dict) and 'result' in response:
-                result = response['result']
-                success = result.get('success', False)
-                # Note: MessageToDict converts snake_case to camelCase
-                error_code = result.get('errorCode', 0)
+            # Extract the command Result. The kachaka high-level client's
+            # start_command() unwraps StartCommandResponse and returns the bare
+            # Result message, so async commands (move_to_pose, return_home)
+            # arrive as {'success': ..., 'errorCode': ...} with no nested
+            # 'result' key. Handle both the bare Result and the wrapped shape;
+            # MessageToDict converts snake_case to camelCase (error_code ->
+            # errorCode) and drops zero-valued fields.
+            result_dict: Optional[Dict[str, Any]] = None
+            if isinstance(response, dict):
+                if isinstance(response.get('result'), dict):
+                    result_dict = response['result']
+                elif 'success' in response:
+                    result_dict = response
+
+            if result_dict is not None:
+                success = result_dict.get('success', False)
+                error_code = result_dict.get('errorCode', 0)
 
                 if self.is_async_command and success:
-                    # Async command started, don't publish completion yet
-                    # publish_result will handle completion after RUNNING state is seen
+                    # Async command started, don't publish completion yet.
+                    # publish_result polls GetCommandState/GetLastCommandResult
+                    # and publishes completion after RUNNING state is seen.
                     self.async_command_started_at = time.monotonic()
                     self.logger.info(f'Async command {method_name} started')
                 elif success:
@@ -1023,7 +1035,7 @@ class KachakaApiClientByZenoh:
                     if publish_completion:
                         self._publish_command_completion(success=False, error_code=error_code)
             else:
-                # No result field (e.g., switch_map), assume success
+                # Response carries no success/result info; assume success.
                 self.logger.info(f'Command {method_name} executed successfully')
                 if publish_completion:
                     self._publish_command_completion(success=True, error_code=0)

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -873,7 +873,10 @@ class KachakaApiClientByZenoh:
             # switch map only if the map is different from the current map id
             # because switch_map method takes long time to complete
             if map_id == current_map_id:
-                self._command_context_map_name = args.get('map_name')
+                rmf_map_name = args.get('map_name')
+                self._command_context_map_name = rmf_map_name
+                self.map_state = self.map_state.with_telemetry_map_name(rmf_map_name)
+                self._publish_to_zenoh(self.map_name_pub, rmf_map_name)
                 self.logger.info('Nothing to do - already on target map')
                 self._publish_command_completion(success=True, error_code=0)
             else:

--- a/scripts/kachaka_client_with_keepalive.py
+++ b/scripts/kachaka_client_with_keepalive.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env pipenv-shebang
+# -*- encoding: utf-8 -*-
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import grpc
+import kachaka_api
+from kachaka_api.base import _resolve_target
+from kachaka_api.base import ShelfLocationResolver
+from kachaka_api.generated.kachaka_api_pb2_grpc import KachakaApiStub
+
+
+class KachakaApiClientWithKeepalive(kachaka_api.KachakaApiClient):
+    """KachakaApiClient with HTTP/2 keepalive enabled for half-open detection.
+
+    The upstream library opens an unconfigured grpc.insecure_channel, leaving
+    no protocol-level liveness check. A persistently unresponsive server then
+    keeps producing DEADLINE_EXCEEDED rather than UNAVAILABLE because the
+    client never realizes the channel is dead.
+
+    This subclass replaces parent initialization to own the channel directly,
+    enabling explicit close during reconstruction and HTTP/2 PINGs that mark
+    the channel BROKEN within keepalive_timeout_ms when ACKs stop arriving.
+    """
+
+    KEEPALIVE_OPTIONS = [
+        ('grpc.keepalive_time_ms', 30000),
+        ('grpc.keepalive_timeout_ms', 10000),
+        ('grpc.keepalive_permit_without_calls', 1),
+        ('grpc.http2.max_pings_without_data', 0),
+    ]
+
+    def __init__(self, target: str = '100.94.1.1:26400') -> None:
+        target_resolved = _resolve_target(target)
+        if target_resolved is None:
+            raise ValueError(f'Invalid target: {target}')
+        self._channel = grpc.insecure_channel(target_resolved, options=self.KEEPALIVE_OPTIONS)
+        self.stub = KachakaApiStub(self._channel)
+        self.resolver = ShelfLocationResolver()
+
+    def close(self) -> None:
+        """Close the underlying gRPC channel. Idempotent."""
+        try:
+            self._channel.close()
+        except Exception:
+            pass

--- a/scripts/rest_kachaka_api.py
+++ b/scripts/rest_kachaka_api.py
@@ -41,7 +41,7 @@ async def init_channel() -> None:
     """
     global kachaka_client
     kachaka_client = kachaka_api.aio.KachakaApiClient(
-        os.getenv("KACHAKA_ACCESS_POINT", "localhost:26400"))
+        os.getenv("KACHAKA_ACCESS_POINT", "100.94.1.1:26400"))
     await kachaka_client.update_resolver()
 
 

--- a/test/test_kachaka_client_with_keepalive.py
+++ b/test/test_kachaka_client_with_keepalive.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for KachakaApiClientWithKeepalive."""
+
+from pathlib import Path
+import sys
+
+import grpc
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+
+from kachaka_client_with_keepalive import KachakaApiClientWithKeepalive  # noqa: E402
+
+
+def test_keepalive_options_present() -> None:
+    """KEEPALIVE_OPTIONS includes the expected gRPC channel arguments."""
+    keys = {opt[0] for opt in KachakaApiClientWithKeepalive.KEEPALIVE_OPTIONS}
+    assert 'grpc.keepalive_time_ms' in keys
+    assert 'grpc.keepalive_timeout_ms' in keys
+    assert 'grpc.keepalive_permit_without_calls' in keys
+
+
+def test_init_creates_channel_and_stub() -> None:
+    """Constructor builds a channel that can be closed without errors."""
+    client = KachakaApiClientWithKeepalive('127.0.0.1:1')
+    channel = client._channel  # noqa: SLF001
+    assert channel is not None
+    assert isinstance(channel, grpc.Channel)
+    assert client.stub is not None
+    client.close()
+
+
+def test_close_is_idempotent() -> None:
+    """close() can be called multiple times without raising."""
+    client = KachakaApiClientWithKeepalive('127.0.0.1:1')
+    client.close()
+    client.close()
+
+
+def test_invalid_target_raises() -> None:
+    """An unresolvable target string surfaces as ValueError."""
+    with pytest.raises(ValueError):
+        KachakaApiClientWithKeepalive('not-a-valid-target-string')

--- a/tests/test_command_lifecycle.py
+++ b/tests/test_command_lifecycle.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for command completion lifecycle."""
+
+# ruff: noqa: SLF001
+
+import asyncio
+import logging
+from pathlib import Path
+import sys
+import threading
+import time
+from typing import Any, Dict, List
+
+from grpc import RpcError  # noqa
+from grpc import StatusCode  # noqa
+import pytest  # noqa
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
+
+from connect_openrmf_by_zenoh import KachakaApiClientByZenoh  # noqa
+from connect_openrmf_by_zenoh import MapState  # noqa
+from connect_openrmf_by_zenoh import Pose  # noqa
+
+
+class FakeRpcError(RpcError):
+    """Minimal RpcError carrying a status code."""
+
+    def __init__(self, status_code: StatusCode) -> None:
+        self._status_code = status_code
+
+    def code(self) -> StatusCode:
+        """Return the gRPC status code."""
+        return self._status_code
+
+    def details(self) -> str:
+        """Return readable error details."""
+        return self._status_code.name
+
+
+class FakeKachakaClient:
+    """Kachaka client double with method responses supplied per test."""
+
+    def __init__(self) -> None:
+        self.responses: Dict[str, Any] = {}
+        self.map_list: List[Dict[str, str]] = [{'id': 'map-1', 'name': 'L1'}]
+        self.current_map_id = 'map-0'
+
+    def get_map_list(self) -> List[Dict[str, str]]:
+        """Return fake map list."""
+        return self.map_list
+
+    def get_current_map_id(self) -> str:
+        """Return fake current map id."""
+        return self.current_map_id
+
+    def move_to_pose(self, **_kwargs: object) -> Dict[str, Any]:
+        """Return fake move_to_pose response."""
+        return self.responses.get('move_to_pose', {'success': True, 'commandId': 'cmd-1'})
+
+    def dock(self, **_kwargs: object) -> Dict[str, Any]:
+        """Return fake dock response."""
+        return self.responses.get('dock', {})
+
+    def switch_map(self, **_kwargs: object) -> Dict[str, Any]:
+        """Return fake switch_map response."""
+        return self.responses.get('switch_map', {'success': True})
+
+
+def make_client() -> KachakaApiClientByZenoh:
+    """Create a bridge instance without opening real gRPC or Zenoh connections."""
+    client = object.__new__(KachakaApiClientByZenoh)
+    client.method_mapping = {}
+    client.map_name_mapping = {}
+    client.reverse_map_name_mapping = {}
+    client.robot_name = 'kachaka'
+    client.task_id = None
+    client.last_command = None
+    client.last_command_result = None
+    client.last_command_id = None
+    client.current_command_id = None
+    client.is_async_command = False
+    client.saw_running = False
+    client.async_command_started_at = None
+    client.running_state_wait = 5.0
+    client.grpc_stuck_threshold = 1.0
+    client.retry_enabled = False
+    client.max_navigation_retries = 0
+    client.retry_interval = 0.0
+    client.retry_on_error_types = []
+    client.retry_count = 0
+    client._first_grpc_failure_time = None
+    client._command_lock = threading.RLock()
+    client._client_lock = threading.RLock()
+    client.logger = logging.getLogger('test_command_lifecycle')
+    client.kachaka_client = FakeKachakaClient()
+    client.kachaka_access_point = None
+    client.last_pose = Pose.zero()
+    client.last_battery = 1.0
+    client.map_state = MapState.initial()
+    client._command_context_map_name = None
+    client.pose_pub = 'pose'
+    client.battery_pub = 'battery'
+    client.map_name_pub = 'map_name'
+    client.command_is_completed_pub = 'completion'
+    client.published = []
+    client.grpc_connection_check = lambda *_args, **_kwargs: True
+
+    def publish_spy(publisher: str, data: object) -> bool:
+        client.published.append((publisher, data))
+        return True
+
+    client._publish_to_zenoh = publish_spy
+    return client
+
+
+def completion_payloads(client: KachakaApiClientByZenoh) -> List[Dict[str, Any]]:
+    """Return command completion payloads published by the bridge."""
+    return [data for publisher, data in client.published if publisher == 'completion']
+
+
+def run_publish_result(client: KachakaApiClientByZenoh) -> None:
+    """Run one async publish_result cycle."""
+    asyncio.run(client.publish_result())
+
+
+def test_move_to_pose_dispatch_does_not_publish_immediate_completion() -> None:
+    """Async dispatch success must not publish is_completed=True immediately."""
+    client = make_client()
+    client.kachaka_client.responses['move_to_pose'] = {'success': True, 'commandId': 'cmd-1'}
+
+    client._execute_command({'id': 'task-1', 'method': 'move_to_pose', 'args': {'x': 1.0, 'y': 2.0, 'yaw': 0.0}})
+
+    assert completion_payloads(client) == []
+    assert client.task_id == 'task-1'
+    assert client.is_async_command is True
+    assert client.current_command_id == 'cmd-1'
+
+
+def test_running_async_command_publishes_incomplete() -> None:
+    """RUNNING state is published as is_completed=False."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.is_async_command = True
+    client.current_command_id = 'cmd-1'
+    client._get_command_state_response = lambda: {'commandId': 'cmd-1', 'state': 'COMMAND_STATE_RUNNING'}
+
+    run_publish_result(client)
+
+    assert completion_payloads(client) == [{'id': 'task-1', 'is_completed': False}]
+    assert client.saw_running is True
+
+
+def test_repeated_running_state_never_publishes_completed_true() -> None:
+    """Repeated RUNNING polls must keep completion false."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.is_async_command = True
+    client.current_command_id = 'cmd-1'
+    client._get_command_state_response = lambda: {'commandId': 'cmd-1', 'state': 'COMMAND_STATE_RUNNING'}
+
+    run_publish_result(client)
+    run_publish_result(client)
+    run_publish_result(client)
+
+    assert completion_payloads(client) == [
+        {
+            'id': 'task-1',
+            'is_completed': False
+        },
+        {
+            'id': 'task-1',
+            'is_completed': False
+        },
+        {
+            'id': 'task-1',
+            'is_completed': False
+        },
+    ]
+
+
+def test_completion_publishes_true_only_for_matching_command_id() -> None:
+    """Completion is accepted only when GetLastCommandResult matches the active command."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.is_async_command = True
+    client.saw_running = True
+    client.current_command_id = 'cmd-1'
+    client._get_command_state_response = lambda: {'commandId': 'cmd-1', 'state': 'COMMAND_STATE_IDLE'}
+    results = iter([
+        {
+            'commandId': 'other-cmd',
+            'result': {
+                'success': True
+            }
+        },
+        {
+            'commandId': 'cmd-1',
+            'result': {
+                'success': True
+            }
+        },
+    ])
+    client._get_last_command_result_response = lambda: next(results)
+
+    run_publish_result(client)
+    assert completion_payloads(client) == []
+
+    run_publish_result(client)
+    assert completion_payloads(client) == [{'id': 'task-1', 'is_completed': True, 'success': True}]
+    assert client.task_id is None
+
+
+@pytest.mark.parametrize('response', [{'success': True}, {'result': {'success': True}}])
+def test_bare_and_wrapped_result_are_treated_as_success(response: Dict[str, Any]) -> None:
+    """Dispatch responses may carry a bare Result or a wrapped Result."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.kachaka_client.responses['dock'] = response
+
+    client._execute_sync_method('dock', {})
+
+    assert completion_payloads(client) == [{'id': 'task-1', 'is_completed': True, 'success': True}]
+
+
+def test_response_without_result_information_is_treated_as_success() -> None:
+    """Responses without result metadata keep the existing success behavior."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.kachaka_client.responses['dock'] = {}
+
+    client._execute_sync_method('dock', {})
+
+    assert completion_payloads(client) == [{'id': 'task-1', 'is_completed': True, 'success': True}]
+
+
+def test_switch_map_publishes_map_name_before_completion() -> None:
+    """switch_map must publish map_name and pose before command completion."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.kachaka_client.responses['switch_map'] = {'success': True}
+
+    client._execute_switch_map_sync({'map_name': 'L1', 'pose': {'x': 3.0, 'y': 4.0, 'theta': 1.57}})
+
+    assert client.published == [
+        ('map_name', 'L1'),
+        ('pose', [3.0, 4.0, 1.57]),
+        ('completion', {
+            'id': 'task-1',
+            'is_completed': True,
+            'success': True
+        }),
+    ]
+
+
+def test_switch_map_bare_failure_result_is_not_treated_as_success() -> None:
+    """A bare failure Result from switch_map must publish failed completion."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.kachaka_client.responses['switch_map'] = {'success': False, 'errorCode': 7}
+
+    client._execute_switch_map_sync({'map_name': 'L1', 'pose': {'x': 0.0, 'y': 0.0, 'theta': 0.0}})
+
+    assert completion_payloads(client) == [{'id': 'task-1', 'is_completed': True, 'success': False}]
+
+
+def test_grpc_stuck_threshold_publishes_failure_and_reconstructs_client() -> None:
+    """Persistent DEADLINE_EXCEEDED completes the task as failure and reconstructs the client."""
+    client = make_client()
+    client.task_id = 'task-1'
+    client.is_async_command = True
+    client.reconstruct_calls = 0
+    client._get_command_state_response = lambda: (_ for _ in ()).throw(FakeRpcError(StatusCode.DEADLINE_EXCEEDED))
+
+    def reconstruct_spy() -> bool:
+        client.reconstruct_calls += 1
+        return True
+
+    client._reconstruct_kachaka_client = reconstruct_spy
+    client._first_grpc_failure_time = time.monotonic() - 2.0
+
+    run_publish_result(client)
+    assert completion_payloads(client) == [{'id': 'task-1', 'is_completed': True, 'success': False}]
+    assert client.reconstruct_calls == 1
+    assert client.task_id is None


### PR DESCRIPTION
## Summary

PR #35 で修正された command completion lifecycle の挙動を regression test として fixate する。
実機 / zenoh router / 外部 gRPC server なしで pytest 実行可能。

### テスト対象シナリオ
- dispatch 後に即時 is_completed=True を publish しない
- RUNNING 中は is_completed=False を維持
- GetLastCommandResult で完了確認後のみ is_completed=True を publish
- bare Result / wrapped Result 両方に対応
- result 情報なし → 成功扱い
- switch_map: map_name publish 後に completion publish（順序保証）
- switch_map bare failure → 失敗扱い（成功扱いしない）
- gRPC stuck threshold 到達時に completion failure + client reconstruct

### 注意
- 本 PR は実装変更なし（テスト追加のみ）
- PR #35 の修正本体を前提にした regression test です
- #38 がマージされた後、main から rebase が必要な場合があります

Closes #39