### PR TITLE
fix: harden kachaka bridge command lifecycle and state reporting

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -26,6 +26,8 @@ timeouts:
 
 # Navigation tolerances (distances in meters, angles in radians)
 navigation:
+  # Set to true to enable the near-target short-circuit below (default off, see PR #48).
+  noop_enabled: false
   # yamllint disable-line rule:line-length
   noop_distance_tolerance: 0.15          # Below this + yaw tolerance, skip Kachaka move_to_pose and report success directly
   noop_yaw_tolerance: 0.10

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,6 +19,23 @@ timeouts:
   grpc_status_check: 5.0    # Timeout for command status gRPC calls (GetCommandState, etc.)
   grpc_stuck: 30.0          # Threshold (sec) for treating persistent Deadline Exceeded as a stuck channel
   command_completion: 180.0 # Watchdog: force failure completion when no RUNNING/completion observed for this long
+  command_start: 15.0       # Max wait for RUNNING after an async command (move_to_pose/return_home) is dispatched
+  motion_progress: 30.0     # Max time with no position/yaw change while RUNNING before treated as stuck
+
+# Navigation tolerances (distances in meters, angles in radians)
+navigation:
+  # yamllint disable-line rule:line-length
+  noop_distance_tolerance: 0.15          # Below this + yaw tolerance, skip Kachaka move_to_pose and report success directly
+  noop_yaw_tolerance: 0.10
+  progress_distance_delta: 0.02          # Minimum position change counted as motion progress while RUNNING
+  progress_yaw_delta: 0.02               # Minimum yaw change counted as motion progress while RUNNING
+  # Tolerance used to confirm a Kachaka success result actually reached the RMF-requested
+  # target (see 7.3). Deliberately looser than noop_*: a real Kachaka move_to_pose success
+  # can land 0.2-0.3m from the exact target, so a tight tolerance here would turn legitimate
+  # successes into spurious failures. Matches the order of magnitude fleet_adapter_zenoh's
+  # localize_guard uses for the same kind of "close enough" check.
+  command_match_distance_tolerance: 0.75
+  command_match_yaw_tolerance: 0.35
 
 intervals:
   command_check: 1.0        # How often to check for new commands

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,8 +21,8 @@ timeouts:
   command_completion: 180.0 # Watchdog: force failure completion when no RUNNING/completion observed for this long
   command_start: 15.0       # Max wait for RUNNING after an async command (move_to_pose/return_home) is dispatched
   motion_progress: 30.0     # Max time with no position/yaw change while RUNNING before treated as stuck
-  own_return_home_retention: 5.0  # Grace period after a dock completes during which a lingering RUNNING
-  # return_home is still recognized as ours, not external (Plan §7.4 concern (b))
+  own_return_home_retention: 5.0  # Grace period after any own async command completes during which a
+  # lingering RUNNING state with the same command_id is still recognized as ours, not external (concern (b))
 
 # Navigation tolerances (distances in meters, angles in radians)
 navigation:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,8 @@ timeouts:
   command_completion: 180.0 # Watchdog: force failure completion when no RUNNING/completion observed for this long
   command_start: 15.0       # Max wait for RUNNING after an async command (move_to_pose/return_home) is dispatched
   motion_progress: 30.0     # Max time with no position/yaw change while RUNNING before treated as stuck
+  own_return_home_retention: 5.0  # Grace period after a dock completes during which a lingering RUNNING
+  # return_home is still recognized as ours, not external (Plan §7.4 concern (b))
 
 # Navigation tolerances (distances in meters, angles in radians)
 navigation:

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -520,6 +520,37 @@ class KachakaApiClientByZenoh:
         yaw_diff = abs(self._normalize_angle(target_yaw - self.last_pose.theta))
         return distance <= distance_tolerance and yaw_diff <= yaw_tolerance
 
+    def _fresh_floor_matches(self, requested_map_name: str) -> bool:
+        """Re-fetch the robot's current floor via gRPC and compare with requested_map_name.
+
+        Gates the near-distance no-op shortcut (Issue #34 Plan §7.1, Codex
+        review ISS34-006 concern (a)): the shortcut must never rely on cached
+        telemetry, because a switch_map racing the last telemetry read would
+        otherwise let a stale floor/pose combination short-circuit to
+        success. Always re-queries, even when the cache already agrees with
+        requested_map_name.
+        """
+        try:
+            current_map_name = self._fetch_robot_map_name(self.grpc_status_check_timeout)
+        except RpcError as e:
+            self._log_error('RPC', '_fresh_floor_matches', e)
+            return False
+        self.map_state = self.map_state.with_telemetry_map_name(current_map_name)
+        self._publish_to_zenoh(self.map_name_pub, current_map_name)
+        return current_map_name == requested_map_name
+
+    def _observed_command_type_matches_expected(self, command_dict: Optional[Dict[str, Any]]) -> bool:
+        """Return True when an observed Kachaka command payload's type matches expected_kachaka_method.
+
+        Used to gate the first bind of current_command_id (Issue #34 Plan
+        §7.3): a RUNNING/result command of the wrong type must never be bound
+        to the active RMF task, even before any command_id has been bound.
+        """
+        expected_field = self.COMMAND_TYPE_FIELD.get(self.expected_kachaka_method or '')
+        if expected_field is None:
+            return True
+        return isinstance(command_dict, dict) and expected_field in command_dict
+
     def _record_motion_progress_baseline(self) -> None:
         """Reset the motion_progress baseline to the current pose and time."""
         self._motion_progress_pose = self.last_pose
@@ -1374,13 +1405,19 @@ class KachakaApiClientByZenoh:
                         target_x = args.get('x')
                         target_y = args.get('y')
                         target_yaw = args.get('yaw', 0.0)
-                        if (target_x is not None and target_y is not None and self._is_near_target(
-                                target_x,
-                                target_y,
-                                target_yaw,
-                                distance_tolerance=self.noop_distance_tolerance,
-                                yaw_tolerance=self.noop_yaw_tolerance,
-                        )):
+                        # map_name is required for the shortcut (a missing floor can
+                        # never be confirmed) and the near-target check runs first
+                        # since it is cheap; the fresh floor re-query only happens
+                        # for candidates that are otherwise about to short-circuit
+                        # (Issue #34 Plan §7.1, Codex review ISS34-006 concern (a)).
+                        if (map_name is not None and target_x is not None and target_y is not None and
+                                self._is_near_target(
+                                    target_x,
+                                    target_y,
+                                    target_yaw,
+                                    distance_tolerance=self.noop_distance_tolerance,
+                                    yaw_tolerance=self.noop_yaw_tolerance,
+                                ) and self._fresh_floor_matches(map_name)):
                             self._log_info(
                                 f'Target within noop tolerance (distance<={self.noop_distance_tolerance}m, '
                                 f'yaw<={self.noop_yaw_tolerance}rad); reporting success without calling Kachaka')

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -1496,14 +1496,10 @@ class KachakaApiClientByZenoh:
                         self.command_target_pose = Pose(target_x or 0.0, target_y or 0.0, target_yaw or 0.0)
                         self.logger.debug(f'Current pose: {self.last_pose.as_list()}')
                         self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
-                        response = self._execute_async_stub_dispatch(method_name, args, task_id=new_task_id)
-                        if self.is_async_command:
-                            self._update_current_command_id(response, method_name)
+                        self._execute_async_stub_dispatch(method_name, args, task_id=new_task_id)
                     elif method_name == 'return_home':
                         self.expected_kachaka_method = 'return_home'
-                        response = self._execute_async_stub_dispatch(method_name, command['args'], task_id=new_task_id)
-                        if self.is_async_command:
-                            self._update_current_command_id(response, method_name)
+                        self._execute_async_stub_dispatch(method_name, command['args'], task_id=new_task_id)
                     else:
                         self.logger.debug(f'{method_name} args: {command["args"]}')
                         self._execute_sync_method(method_name, command['args'], task_id=new_task_id)
@@ -1751,10 +1747,19 @@ class KachakaApiClientByZenoh:
                 # slow grpc_connection_check above does not eat into the
                 # budget before the command was actually sent (Issue #34
                 # Plan §7.2, Codex review ISS34-006 non-blocking finding).
+                #
+                # command_dispatched_at/async_command_started_at and
+                # current_command_id are bound inside the same _command_lock
+                # acquisition so monitor_external_control() (a different
+                # thread) can never observe dispatched_at set while
+                # current_command_id is still unbound -- that gap let a
+                # racing own returnHome be misclassified as external and
+                # preempted (Codex re-review ISS34-016 blocking-1).
                 now = time.monotonic()
-                self.async_command_started_at = now
                 with self._command_lock:
+                    self.async_command_started_at = now
                     self.command_dispatched_at = now
+                    self._update_current_command_id(response_dict, method_name)
                 self.logger.info(f'Async command {method_name} started')
             else:
                 self._log_warning(f'Command {method_name} failed with error_code={error_code}')

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -1096,20 +1096,26 @@ class KachakaApiClientByZenoh:
                             command_id,
                         )
                         return
-                    if command_id != self.current_command_id:
+                if self._is_running_state(state_value):
+                    if self.is_async_command and command_id != self.current_command_id:
                         # A required exact match, not just a mismatch check
                         # when both sides are non-empty: an empty/missing
                         # commandId here must never be treated as "still
                         # ours". Kachaka API 3.14.4.0's own client wrapper
                         # requires result.command_id == response.command_id
                         # while waiting for completion, so a genuinely
-                        # RUNNING/completed own command is expected to keep
-                        # reporting a non-empty id (Codex re-review
-                        # ISS34-040 blocking-A).
+                        # RUNNING own command is expected to keep reporting
+                        # a non-empty id (Codex re-review ISS34-040
+                        # blocking-A). This check only gates RUNNING being
+                        # accepted as our own progress; a non-RUNNING state
+                        # (e.g. Kachaka's observed post-completion
+                        # COMMAND_STATE_PENDING/id-less transition, Codex
+                        # re-review ISS34-042) must fall through to
+                        # GetLastCommandResult below instead of returning
+                        # here, since completion ownership is judged by the
+                        # result commandId match, not the state one.
                         self._note_ignored_mismatch('command state', command_id)
                         return
-
-                if self._is_running_state(state_value):
                     self.saw_running = True
                     self.last_progress_at = time.monotonic()
                     self._ignored_result_count = 0

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -698,25 +698,24 @@ class KachakaApiClientByZenoh:
         """Return True when a RUNNING returnHomeCommand belongs to our own dispatched dock.
 
         RMF issues return_home via the 'dock' RMF method (mapped to Kachaka's
-        return_home). Once current_command_id has been bound, ownership is
-        decided purely by ID equality. Before it is bound, the observed id
-        cannot yet be compared; an unbound id is treated as plausibly ours
-        only within running_state_wait of our own dispatch (the window in
-        which our own RUNNING is expected to appear) -- not indefinitely, so
-        a genuinely external returnHome that starts before ours binds is
-        eventually recognized as external instead of being assumed ours
-        forever (Issue #34 Plan §7.4, Codex review ISS34-006 blocking
-        finding). A dock that completed just before this poll is still
-        recognized via the short-lived _recently_own_return_home_* grace
-        period (concern (b)), so the trailing RUNNING state Kachaka can
-        report right after completion is not mistaken for external control.
+        return_home). Ownership is decided purely by command_id equality:
+        move_to_pose/return_home dispatch captures command_id synchronously
+        via stub.StartCommand() (see _execute_async_stub_dispatch), so
+        current_command_id is bound before this is ever consulted. An unbound
+        current_command_id is therefore treated as not ours -- never as
+        plausibly ours within a grace window -- so a genuinely external
+        returnHome racing our own dispatch is recognized as external instead
+        of being assumed ours (Issue #34 Plan §7.4, Codex re-review ISS34-010
+        blocking-3: the previous running_state_wait-window fallback assumed
+        an unbound id was ours, which misclassified an external returnHome
+        arriving in that window as our own). A dock that completed just
+        before this poll is still recognized via the short-lived
+        _recently_own_return_home_* grace period (concern (b)), so the
+        trailing RUNNING state Kachaka can report right after completion is
+        not mistaken for external control.
         """
         if self.task_id is not None and self.last_command is not None and self.last_command.get('method') == 'dock':
-            if self.current_command_id is not None:
-                return self.current_command_id == observed_command_id
-            if self.command_dispatched_at is None:
-                return False
-            return (time.monotonic() - self.command_dispatched_at) < self.running_state_wait
+            return self.current_command_id is not None and self.current_command_id == observed_command_id
 
         if (self._recently_own_return_home_id is not None and
                 observed_command_id == self._recently_own_return_home_id and
@@ -1312,30 +1311,6 @@ class KachakaApiClientByZenoh:
             # Wait before next check
             await asyncio.sleep(self.command_check_interval)
 
-    def _prepare_async_command_args(self,
-                                    args: Dict[str, Any],
-                                    defaults: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        """Prepare arguments for async StartCommand methods.
-
-        Sets wait_for_completion=False by default and updates is_async_command flag.
-
-        Args:
-            args: Original command arguments
-            defaults: Additional default values to set if not present
-
-        Returns:
-            Prepared arguments dict
-        """
-        prepared = args.copy() if args else {}
-        if defaults:
-            for key, value in defaults.items():
-                if key not in prepared:
-                    prepared[key] = value
-        if 'wait_for_completion' not in prepared:
-            prepared['wait_for_completion'] = False
-        self.is_async_command = not prepared.get('wait_for_completion', True)
-        return prepared
-
     def _complete_superseded_task(self, new_task_id: Optional[str]) -> None:
         """Mark the current active task as superseded before accepting a new one."""
         if not self.task_id or self.task_id == new_task_id:
@@ -1469,11 +1444,12 @@ class KachakaApiClientByZenoh:
                     self.saw_running = False
                     self.async_command_started_at = None
                     self.last_progress_at = time.monotonic()
-                    # Set to the actual dispatch-success time in _execute_sync_method,
-                    # not here: grpc_connection_check can stall before the real send,
-                    # which would otherwise eat into the command_start budget before
-                    # the command was even sent (Issue #34 Plan §7.2, Codex review
-                    # ISS34-006 non-blocking finding).
+                    # Set to the actual dispatch-success time in
+                    # _execute_async_stub_dispatch/_execute_sync_method, not
+                    # here: grpc_connection_check can stall before the real
+                    # send, which would otherwise eat into the command_start
+                    # budget before the command was even sent (Issue #34 Plan
+                    # §7.2, Codex review ISS34-006 non-blocking finding).
                     self.command_dispatched_at = None
                     self._motion_progress_pose = None
                     self._motion_progress_at = None
@@ -1518,16 +1494,14 @@ class KachakaApiClientByZenoh:
                         self.expected_kachaka_method = 'move_to_pose'
                         self.command_target_map_name = map_name
                         self.command_target_pose = Pose(target_x or 0.0, target_y or 0.0, target_yaw or 0.0)
-                        args = self._prepare_async_command_args(args, {'cancel_all': True})
                         self.logger.debug(f'Current pose: {self.last_pose.as_list()}')
                         self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
-                        response = self._execute_sync_method(method_name, args, task_id=new_task_id)
+                        response = self._execute_async_stub_dispatch(method_name, args, task_id=new_task_id)
                         if self.is_async_command:
                             self._update_current_command_id(response, method_name)
                     elif method_name == 'return_home':
                         self.expected_kachaka_method = 'return_home'
-                        args = self._prepare_async_command_args(command['args'])
-                        response = self._execute_sync_method(method_name, args, task_id=new_task_id)
+                        response = self._execute_async_stub_dispatch(method_name, command['args'], task_id=new_task_id)
                         if self.is_async_command:
                             self._update_current_command_id(response, method_name)
                     else:
@@ -1698,6 +1672,104 @@ class KachakaApiClientByZenoh:
         if 'success' in response or 'errorCode' in response:
             return response
         return None
+
+    def _build_stub_start_command_request(self, method_name: str, args: Dict[str, Any]) -> pb2.StartCommandRequest:
+        """Build the StartCommandRequest for a stub-direct async dispatch.
+
+        Mirrors the pb2.Command the installed kachaka_api library's
+        move_to_pose()/return_home() wrappers build internally (see
+        kachaka_api/base.py), so calling stub.StartCommand() with this
+        request has the same effect on the robot as going through the
+        wrapper -- except the response keeps command_id, which the wrapper
+        discards (Issue #34 Plan §7.3/§7.4, Codex re-review ISS34-010
+        blocking-3).
+        """
+        if method_name == 'move_to_pose':
+            command = pb2.Command(move_to_pose_command=pb2.MoveToPoseCommand(
+                x=args.get('x', 0.0),
+                y=args.get('y', 0.0),
+                yaw=args.get('yaw', 0.0),
+            ))
+        elif method_name == 'return_home':
+            command = pb2.Command(return_home_command=pb2.ReturnHomeCommand())
+        else:
+            raise ValueError(f'Unsupported stub dispatch method: {method_name}')
+        return pb2.StartCommandRequest(command=command, cancel_all=args.get('cancel_all', True))
+
+    def _execute_async_stub_dispatch(
+        self,
+        method_name: str,
+        args: Dict[str, Any],
+        task_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Dispatch move_to_pose/return_home via stub.StartCommand() directly.
+
+        The installed kachaka_api library's move_to_pose()/return_home()
+        wrappers call start_command(), which discards
+        StartCommandResponse.command_id whenever wait_for_completion is
+        False (the mode this bridge always uses): ``if not
+        response.result.success or not wait_for_completion: return
+        response.result``. Calling stub.StartCommand() directly instead
+        keeps command_id, so bind (§7.3) and ownership (§7.4) judgments can
+        key off ID equality from dispatch onward. This path replaces
+        _execute_sync_method for move_to_pose/return_home only; every other
+        method_mapping-driven method still goes through the generic wrapper
+        dispatch there (Issue #34 Plan §7.3/§7.4, Codex re-review ISS34-010
+        blocking-3).
+
+        Args:
+            method_name (str): 'move_to_pose' or 'return_home'.
+            args (Dict[str, Any]): The command arguments (x/y/yaw for
+                move_to_pose; cancel_all applies to both, defaulting to True).
+            task_id (str, optional): The ID of the command being executed.
+                Completions are published for this ID so they can never be
+                attributed to a different (newer) task.
+
+        Returns:
+            Dict[str, Any]: {'result': {...}, 'commandId': ...} shaped like
+            _to_dict(StartCommandResponse), so _update_current_command_id
+            and the existing async-started bookkeeping apply unchanged.
+        """
+        self.is_async_command = True
+        try:
+            if not self.grpc_connection_check(max_retries=self.command_max_retries):
+                error_msg = f'Failed to connect to Kachaka API server for method {method_name}'
+                self.logger.error(error_msg)
+                self._publish_command_completion(success=False, error_code=-1, task_id=task_id)
+                raise ConnectionError(error_msg)
+
+            request = self._build_stub_start_command_request(method_name, args)
+            response_dict = self._to_dict(self.kachaka_client.stub.StartCommand(request))
+
+            result_dict = response_dict.get('result', {}) if isinstance(response_dict, dict) else {}
+            success = result_dict.get('success', False)
+            error_code = result_dict.get('errorCode', 0)
+
+            if success:
+                # Origin of the command_start timeout is dispatch success
+                # (here), not command acceptance in _execute_command, so a
+                # slow grpc_connection_check above does not eat into the
+                # budget before the command was actually sent (Issue #34
+                # Plan §7.2, Codex review ISS34-006 non-blocking finding).
+                now = time.monotonic()
+                self.async_command_started_at = now
+                with self._command_lock:
+                    self.command_dispatched_at = now
+                self.logger.info(f'Async command {method_name} started')
+            else:
+                self._log_warning(f'Command {method_name} failed with error_code={error_code}')
+                self._publish_command_completion(success=False, error_code=error_code, task_id=task_id)
+
+            return response_dict
+
+        except RpcError as e:
+            self.logger.error(f'RPC error in {method_name}: {e.details()}')
+            self._publish_command_completion(success=False, error_code=-1, task_id=task_id)
+            raise
+        except Exception as e:
+            self.logger.error(f'Unexpected error in {method_name}: {str(e)}')
+            self._publish_command_completion(success=False, error_code=-1, task_id=task_id)
+            raise
 
     def _execute_sync_method(
         self,

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -172,8 +172,8 @@ class KachakaApiClientByZenoh:
     external_control_active: bool
     own_return_home_retention: float
 
-    # Consecutive command_id mismatches tolerated before undoing a binding
-    # (one mismatch is observed roughly once per main loop iteration).
+    # Consecutive command_id mismatches logged before re-warning (own binding
+    # is never undone by a mismatch -- see _note_ignored_mismatch).
     MAX_IGNORED_MISMATCHES = 5
 
     # Maps the internal (post method_mapping) Kachaka method name to the
@@ -184,6 +184,20 @@ class KachakaApiClientByZenoh:
         'move_to_pose': 'moveToPoseCommand',
         'return_home': 'returnHomeCommand',
     }
+
+    # Kachaka command types known to occupy the robot's movement/command
+    # slot; used only to log a clear diagnostic when a RUNNING command's type
+    # is not one of these. Detection itself never gates on this set: a
+    # non-own RUNNING command of any (including unrecognized) type is
+    # treated as external, since the real Kachaka app's Return Home button
+    # was observed on hardware to issue moveToLocationCommand rather than
+    # returnHomeCommand (ISS34-034), and any future/unknown command type must
+    # default to busy rather than being silently ignored (Issue #34 Plan §5).
+    KNOWN_MOVEMENT_COMMAND_FIELDS = frozenset({
+        'returnHomeCommand',
+        'moveToLocationCommand',
+        'moveToPoseCommand',
+    })
 
     def __init__(
         self,
@@ -328,16 +342,19 @@ class KachakaApiClientByZenoh:
         self.expected_kachaka_method: Optional[str] = None
         self.command_target_map_name: Optional[str] = None
         self.command_target_pose: Optional[Pose] = None
-        # True while an externally-triggered returnHome (not issued by this
-        # bridge) is observed running on the robot (Issue #34 Plan §7.4).
+        # True while a RUNNING Kachaka command not issued by this bridge is
+        # observed on the robot (Issue #34 Plan §5/§7.4, generalized from
+        # returnHome-only to any command type -- ISS34-034/ISS34-035).
         self.external_control_active = False
         self._external_command_id: Optional[str] = None
-        # The command_id and expiry of the own dock (return_home) that most
-        # recently completed; lets _is_own_return_home() still recognize a
-        # briefly-lingering RUNNING return_home as ours after task_id has
-        # already been reset (Issue #34 Plan §7.4, Codex review concern (b)).
-        self._recently_own_return_home_id: Optional[str] = None
-        self._recently_own_return_home_until: Optional[float] = None
+        # The command_id and expiry of the own async command (any method,
+        # not only dock/return_home) that most recently completed; lets
+        # _is_own_command_id() still recognize a briefly-lingering RUNNING
+        # command as ours after task_id has already been reset (Issue #34
+        # Plan §5, generalized from the return_home-only grace period,
+        # Codex review concern (b)).
+        self._recently_completed_own_command_id: Optional[str] = None
+        self._recently_completed_own_command_until: Optional[float] = None
         # Monotonically increasing sequence number for the unified state
         # payload (Issue #34 Plan §5.1).
         self._state_seq = 0
@@ -486,18 +503,27 @@ class KachakaApiClientByZenoh:
         return (time.monotonic() - self.last_progress_at) >= self.command_completion_timeout
 
     def _note_ignored_mismatch(self, source: str, observed_id: Optional[str]) -> None:
-        """Track command_id mismatches and undo a wrong binding when persistent.
+        """Log a persistent command_id mismatch without ever undoing the own binding.
 
-        Binding the wrong command_id (e.g. the previous command's RUNNING state
-        observed right after cancel_all) would otherwise make every later
-        state/result be ignored and the completion never reach RMF.
+        Never clears current_command_id. StartCommand's response binds our
+        own command_id synchronously at dispatch (_execute_async_stub_dispatch),
+        so once bound it is authoritative for the life of the task; a
+        mismatch here just means Kachaka is reporting a different command's
+        state/result, not evidence that our own binding was wrong. Unbinding
+        used to let a persistent external command_id whose type/target
+        happened to match the dispatched task rebind onto this task once
+        _ignored_result_count reached MAX_IGNORED_MISMATCHES -- a same-type,
+        same-ish-target external command could then be silently attributed
+        to this task's completion (ISS34-035 gap analysis). A genuinely
+        external command is instead handled by monitor_external_control(),
+        which preempts this task outright rather than waiting for repeated
+        mismatches (Issue #34 Plan §5).
         """
         self._ignored_result_count += 1
         if self._ignored_result_count >= self.MAX_IGNORED_MISMATCHES:
             self._log_warning(f'{source} command_id {observed_id} mismatched bound '
                               f'{self.current_command_id} {self._ignored_result_count} consecutive times; '
-                              'unbinding to allow re-binding')
-            self.current_command_id = None
+                              'still ignoring (own binding is never undone by a mismatch)')
             self._ignored_result_count = 0
         else:
             self.logger.debug(
@@ -596,6 +622,21 @@ class KachakaApiClientByZenoh:
         every command_id-binding call site rejects a same-type command that
         cannot be confirmed as ours, rather than binding on type alone
         (Codex re-review ISS34-010 blocking-2, Issue #34 Plan §7.3).
+
+        Residual scope note (ISS34-036): this type/target confirmation is
+        only ever consulted by publish_result()'s first-bind path, reached
+        solely when current_command_id was never captured at dispatch (a
+        successful StartCommand response with no command_id) -- an anomaly
+        the stub-direct dispatch was specifically introduced to eliminate
+        (ISS34-002-fix3), so it should not occur in practice. If it ever
+        does and a same-type/target external command races it, monitor_
+        external_control() still runs first every main loop iteration and
+        polls independently; ownership here is decided by type/target, not
+        by the bounded own-id set _is_own_command_id() uses. Removing this
+        path entirely (fail the task via command_start_timeout instead of
+        ever binding without a captured id) was considered but left out of
+        this change's scope to avoid destabilizing the ISS34-006/ISS34-010
+        binding behavior these type/target checks were reviewed for.
         """
         if not self._observed_command_type_matches_expected(command_dict):
             return False
@@ -696,63 +737,78 @@ class KachakaApiClientByZenoh:
 
         return True, None
 
-    def _is_own_return_home(self, observed_command_id: Optional[str]) -> bool:
-        """Return True when a RUNNING returnHomeCommand belongs to our own dispatched dock.
+    def _is_own_command_id(self, observed_command_id: Optional[str]) -> bool:
+        """Return True when a RUNNING command's id belongs to this bridge's own dispatch.
 
-        RMF issues return_home via the 'dock' RMF method (mapped to Kachaka's
-        return_home). Ownership is decided purely by command_id equality:
+        Ownership is decided purely by command_id equality against the
+        bounded own-id set -- the currently bound dispatch (any method:
         move_to_pose/return_home dispatch captures command_id synchronously
-        via stub.StartCommand() (see _execute_async_stub_dispatch), so
-        current_command_id is bound before this is ever consulted. An unbound
-        current_command_id is therefore treated as not ours -- never as
-        plausibly ours within a grace window -- so a genuinely external
-        returnHome racing our own dispatch is recognized as external instead
-        of being assumed ours (Issue #34 Plan §7.4, Codex re-review ISS34-010
-        blocking-3: the previous running_state_wait-window fallback assumed
-        an unbound id was ours, which misclassified an external returnHome
-        arriving in that window as our own). A dock that completed just
-        before this poll is still recognized via the short-lived
-        _recently_own_return_home_* grace period (concern (b)), so the
-        trailing RUNNING state Kachaka can report right after completion is
-        not mistaken for external control.
-        """
-        if self.task_id is not None and self.last_command is not None and self.last_command.get('method') == 'dock':
-            return self.current_command_id is not None and self.current_command_id == observed_command_id
+        via stub.StartCommand(), see _execute_async_stub_dispatch) or a
+        just-completed/just-superseded own command still within its
+        retention grace period. Command type/target are never consulted
+        here (Issue #34 Plan §5, generalized from a return_home-only,
+        dock-method-gated check to any RMF-dispatched command -- ISS34-034
+        found the real Kachaka app's Return Home button issues
+        moveToLocationCommand, not returnHomeCommand, so a type-specific
+        check misses it entirely).
 
-        if (self._recently_own_return_home_id is not None and
-                observed_command_id == self._recently_own_return_home_id and
-                self._recently_own_return_home_until is not None and
-                time.monotonic() < self._recently_own_return_home_until):
+        An unbound current_command_id is therefore treated as not ours --
+        never as plausibly ours within a grace window -- so a genuinely
+        external command racing our own dispatch (still in flight, not yet
+        bound) is recognized as external instead of being assumed ours
+        (Codex re-review ISS34-010 blocking-3). A command that completed
+        just before this poll is still recognized via the short-lived
+        _recently_completed_own_command_* grace period (concern (b)), so
+        the trailing RUNNING state Kachaka can report right after
+        completion or cancellation/supersession is not mistaken for
+        external control.
+        """
+        if observed_command_id is None:
+            return False
+        if self.current_command_id is not None and observed_command_id == self.current_command_id:
+            return True
+        if (self._recently_completed_own_command_id is not None and
+                observed_command_id == self._recently_completed_own_command_id and
+                self._recently_completed_own_command_until is not None and
+                time.monotonic() < self._recently_completed_own_command_until):
             return True
         return False
 
-    def _handle_external_return_home_started(self, command_id: Optional[str]) -> None:
+    def _handle_external_command_started(self, command_id: Optional[str]) -> None:
         """Preempt any active RMF task and mark external control as active."""
         preempted_task_id = self.task_id
         if preempted_task_id is not None:
-            self._log_error_msg(f'External returnHome (command_id={command_id}) observed; '
-                                f'preempting active RMF task {preempted_task_id}')
+            self._log_error_msg(
+                f'External command (command_id={command_id}) observed; preempting active RMF task {preempted_task_id}')
             self._publish_command_completion(success=False,
                                              error_code=-8,
                                              task_id=preempted_task_id,
                                              reason='external_preempted')
         else:
-            self._log_info(f'External returnHome (command_id={command_id}) observed while idle')
+            self._log_info(f'External command (command_id={command_id}) observed while idle')
         self.external_control_active = True
         self._external_command_id = command_id
 
-    def _handle_external_return_home_ended(self) -> None:
+    def _handle_external_command_ended(self) -> None:
         """Mark external control as no longer active."""
-        self._log_info(f'External returnHome (command_id={self._external_command_id}) ended')
+        self._log_info(f'External command (command_id={self._external_command_id}) ended')
         self.external_control_active = False
         self._external_command_id = None
 
     async def monitor_external_control(self) -> None:
-        """Detect Kachaka commands not issued by this bridge (Issue #34 Plan §7.4).
+        """Detect Kachaka commands not issued by this bridge (Issue #34 Plan §5).
 
         Runs every main loop iteration regardless of whether an RMF task is
-        active, so an externally-triggered returnHome (e.g. from the Kachaka
-        app or a low-battery auto-return) is observed even while idle.
+        active, so an externally-triggered command (e.g. the Kachaka app's
+        Return Home button, a low-battery auto-return, or a direct API call)
+        is observed even while idle. Detection is generalized from a
+        returnHomeCommand-only check to any RUNNING command whose command_id
+        is not in the bounded own-id set (see _is_own_command_id):
+        moveToLocationCommand/moveToPoseCommand are common examples, and an
+        unrecognized command type still defaults to busy rather than being
+        silently ignored (ISS34-034 found the real Return Home button issues
+        moveToLocationCommand, which the previous returnHomeCommand-only
+        check never caught).
         """
         method_name = 'monitor_external_control'
         try:
@@ -764,18 +820,38 @@ class KachakaApiClientByZenoh:
             return
 
         with self._command_lock:
+            if self.dispatching:
+                # A dispatch is in flight and has not yet synchronously bound
+                # its own command_id (_execute_async_stub_dispatch runs the
+                # gRPC call outside _command_lock while dispatching=True).
+                # Judging ownership now could misclassify our own
+                # not-yet-bound dispatch as external; defer to the next poll,
+                # by which point the dispatch has either bound
+                # current_command_id or failed and reset task_id (Issue #34
+                # Plan §5 dispatch-pending hold).
+                return
+
             command_dict = state_res.get('command')
-            is_return_home = isinstance(command_dict, dict) and 'returnHomeCommand' in command_dict
             is_running = self._is_running_state(state_res.get('state'))
             observed_id = state_res.get('commandId')
+            is_external_now = is_running and observed_id is not None and not self._is_own_command_id(observed_id)
 
-            is_external_now = (is_return_home and is_running and observed_id is not None and
-                               not self._is_own_return_home(observed_id))
-
-            if is_external_now and not self.external_control_active:
-                self._handle_external_return_home_started(observed_id)
-            elif not is_external_now and self.external_control_active:
-                self._handle_external_return_home_ended()
+            if is_external_now:
+                if not isinstance(command_dict, dict) or not any(field in command_dict
+                                                                 for field in self.KNOWN_MOVEMENT_COMMAND_FIELDS):
+                    self.logger.warning(
+                        'Unrecognized RUNNING command type %r (command_id=%s); defaulting to busy',
+                        command_dict,
+                        observed_id,
+                    )
+                if not self.external_control_active:
+                    self._handle_external_command_started(observed_id)
+                elif observed_id != self._external_command_id:
+                    self._log_info(f'External command switched from {self._external_command_id} to {observed_id}; '
+                                   'external_control_active remains True')
+                    self._external_command_id = observed_id
+            elif self.external_control_active:
+                self._handle_external_command_ended()
 
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh.
@@ -1132,7 +1208,7 @@ class KachakaApiClientByZenoh:
                 # Publish and reset
                 self.last_command_result = result
                 if self._publish_to_zenoh(self.command_is_completed_pub, result.as_payload()) and result.is_completed:
-                    self._record_own_return_home_retention()
+                    self._record_recently_completed_own_command()
                     self._reset_async_command_state()
 
         except RpcError as e:
@@ -1855,22 +1931,26 @@ class KachakaApiClientByZenoh:
             self._publish_command_completion(success=False, error_code=-1, task_id=task_id)
             raise
 
-    def _record_own_return_home_retention(self) -> None:
-        """Remember a completing dock's command_id for the ownership grace period.
+    def _record_recently_completed_own_command(self) -> None:
+        """Remember a completing own command's command_id for the ownership grace period.
 
-        Must run on every completion path immediately before
-        _reset_async_command_state() clears current_command_id, not only
-        the explicit _publish_command_completion() path: publish_result()'s
+        Applies to any completing method (move_to_pose, dock/return_home,
+        ...) that had a bound command_id, not only dock -- generalized from
+        the previous dock-only check so a briefly-lingering RUNNING state
+        after any own command's completion or cancellation/supersession is
+        still recognized as ours (Issue #34 Plan §5, concern (b)). Must run
+        on every completion path immediately before
+        _reset_async_command_state() clears current_command_id, not only the
+        explicit _publish_command_completion() path: publish_result()'s
         normal async-success completion calls _reset_async_command_state()
         directly and previously bypassed this recording entirely, so
-        _is_own_return_home() had no record to recognize a briefly-lingering
-        RUNNING return_home right after an ordinary dock success (Issue #34
-        Plan §7.4 concern (b), Codex re-review ISS34-010 recommendation-2).
+        _is_own_command_id() had no record to recognize a briefly-lingering
+        RUNNING command right after an ordinary success (Codex re-review
+        ISS34-010 recommendation-2).
         """
-        if (self.last_command is not None and self.last_command.get('method') == 'dock' and
-                self.current_command_id is not None):
-            self._recently_own_return_home_id = self.current_command_id
-            self._recently_own_return_home_until = time.monotonic() + self.own_return_home_retention
+        if self.current_command_id is not None:
+            self._recently_completed_own_command_id = self.current_command_id
+            self._recently_completed_own_command_until = time.monotonic() + self.own_return_home_retention
 
     def _reset_async_command_state(self) -> None:
         """Reset all async command tracking state.
@@ -1969,7 +2049,7 @@ class KachakaApiClientByZenoh:
 
             # Clear all async command tracking state after publishing
             if target_task_id == self.task_id:
-                self._record_own_return_home_retention()
+                self._record_recently_completed_own_command()
                 self._reset_async_command_state()
             return True
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -169,6 +169,7 @@ class KachakaApiClientByZenoh:
     command_target_map_name: Optional[str]
     command_target_pose: Optional[Pose]
     external_control_active: bool
+    own_return_home_retention: float
 
     # Consecutive command_id mismatches tolerated before undoing a binding
     # (one mismatch is observed roughly once per main loop iteration).
@@ -231,6 +232,7 @@ class KachakaApiClientByZenoh:
         self.command_completion_timeout = float(timeouts.get('command_completion', 180.0))
         self.command_start_timeout = float(timeouts.get('command_start', 15.0))
         self.motion_progress_timeout = float(timeouts.get('motion_progress', 30.0))
+        self.own_return_home_retention = float(timeouts.get('own_return_home_retention', 5.0))
         self.command_check_interval = intervals.get('command_check', 4.0)
 
         # Load navigation tolerance settings (Issue #34 Plan §7.1-§7.3)
@@ -328,6 +330,12 @@ class KachakaApiClientByZenoh:
         # bridge) is observed running on the robot (Issue #34 Plan §7.4).
         self.external_control_active = False
         self._external_command_id: Optional[str] = None
+        # The command_id and expiry of the own dock (return_home) that most
+        # recently completed; lets _is_own_return_home() still recognize a
+        # briefly-lingering RUNNING return_home as ours after task_id has
+        # already been reset (Issue #34 Plan §7.4, Codex review concern (b)).
+        self._recently_own_return_home_id: Optional[str] = None
+        self._recently_own_return_home_until: Optional[float] = None
         # Monotonically increasing sequence number for the unified state
         # payload (Issue #34 Plan §5.1).
         self._state_seq = 0
@@ -650,16 +658,32 @@ class KachakaApiClientByZenoh:
         """Return True when a RUNNING returnHomeCommand belongs to our own dispatched dock.
 
         RMF issues return_home via the 'dock' RMF method (mapped to Kachaka's
-        return_home). Before the command_id has been bound (early in the
-        dispatch), the observed id cannot yet be compared, so any RUNNING
-        return_home while our own dock task is in flight is treated as ours
-        (Issue #34 Plan §7.4).
+        return_home). Once current_command_id has been bound, ownership is
+        decided purely by ID equality. Before it is bound, the observed id
+        cannot yet be compared; an unbound id is treated as plausibly ours
+        only within running_state_wait of our own dispatch (the window in
+        which our own RUNNING is expected to appear) -- not indefinitely, so
+        a genuinely external returnHome that starts before ours binds is
+        eventually recognized as external instead of being assumed ours
+        forever (Issue #34 Plan §7.4, Codex review ISS34-006 blocking
+        finding). A dock that completed just before this poll is still
+        recognized via the short-lived _recently_own_return_home_* grace
+        period (concern (b)), so the trailing RUNNING state Kachaka can
+        report right after completion is not mistaken for external control.
         """
-        if self.task_id is None or self.last_command is None:
-            return False
-        if self.last_command.get('method') != 'dock':
-            return False
-        return self.current_command_id is None or self.current_command_id == observed_command_id
+        if self.task_id is not None and self.last_command is not None and self.last_command.get('method') == 'dock':
+            if self.current_command_id is not None:
+                return self.current_command_id == observed_command_id
+            if self.command_dispatched_at is None:
+                return False
+            return (time.monotonic() - self.command_dispatched_at) < self.running_state_wait
+
+        if (self._recently_own_return_home_id is not None and
+                observed_command_id == self._recently_own_return_home_id and
+                self._recently_own_return_home_until is not None and
+                time.monotonic() < self._recently_own_return_home_until):
+            return True
+        return False
 
     def _handle_external_return_home_started(self, command_id: Optional[str]) -> None:
         """Preempt any active RMF task and mark external control as active."""
@@ -1793,6 +1817,15 @@ class KachakaApiClientByZenoh:
 
             # Clear all async command tracking state after publishing
             if target_task_id == self.task_id:
+                if (self.last_command is not None and self.last_command.get('method') == 'dock' and
+                        self.current_command_id is not None):
+                    # Issue #34 Plan §7.4 concern (b): Kachaka can still report a
+                    # brief lingering RUNNING return_home right after this dock
+                    # completes; remember its id for a short grace period so it
+                    # is not mistaken for an external returnHome once task_id is
+                    # cleared below.
+                    self._recently_own_return_home_id = self.current_command_id
+                    self._recently_own_return_home_until = time.monotonic() + self.own_return_home_retention
                 self._reset_async_command_state()
             return True
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -622,7 +622,7 @@ class KachakaApiClientByZenoh:
             return True, None
 
         command_dict = last_result.get('command')
-        if not isinstance(command_dict, dict) or expected_field not in command_dict:
+        if not self._observed_command_type_matches_expected(command_dict):
             self._log_warning(
                 f'Command type mismatch for task {self.task_id}: expected {expected_field}, got {command_dict!r}')
             return False, None
@@ -933,12 +933,25 @@ class KachakaApiClientByZenoh:
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
+                command_dict = state_res.get('command') if isinstance(state_res, dict) else None
 
                 if self.is_async_command and not self.saw_running and self._command_start_timeout_expired():
                     self._handle_async_timeout(error_code=-6, reason='start_timeout')
                     return
 
                 if self.is_async_command:
+                    if (self.current_command_id is None and self._is_running_state(state_value) and
+                            not self._observed_command_type_matches_expected(command_dict)):
+                        # A RUNNING command of the wrong type must never be bound to
+                        # this task, even before any command_id has been bound
+                        # (Issue #34 Plan §7.3, Codex review ISS34-006 blocking finding).
+                        self.logger.debug(
+                            'Ignoring RUNNING command_id %s for task %s: type mismatch (expected %s)',
+                            command_id,
+                            self.task_id,
+                            self.expected_kachaka_method,
+                        )
+                        return
                     if command_id:
                         if self.current_command_id is None and self._is_running_state(state_value):
                             self.current_command_id = command_id
@@ -973,7 +986,8 @@ class KachakaApiClientByZenoh:
                     return
 
                 if self.is_async_command and not self.saw_running:
-                    if self.current_command_id is None and command_id and self._running_state_wait_expired():
+                    if (self.current_command_id is None and command_id and self._running_state_wait_expired() and
+                            self._observed_command_type_matches_expected(command_dict)):
                         self.current_command_id = command_id
                         self._log_warning(f'RUNNING state was not observed within {self.running_state_wait}s; '
                                           f'falling back to command_id={command_id} for task {self.task_id}')
@@ -986,8 +1000,14 @@ class KachakaApiClientByZenoh:
                 self._first_grpc_failure_time = None
                 self.logger.debug(f'GetLastCommandResult response: {last_result}')
                 result_command_id = last_result.get('commandId')
+                result_command_dict = last_result.get('command') if isinstance(last_result, dict) else None
 
                 if self.is_async_command:
+                    if (self.current_command_id is None and self.saw_running and result_command_id and
+                            not self._observed_command_type_matches_expected(result_command_dict)):
+                        self._log_warning(f'Ignoring result command_id {result_command_id} for task {self.task_id}: '
+                                          f'type mismatch (expected {self.expected_kachaka_method})')
+                        return
                     if result_command_id:
                         if self.current_command_id is None and self.saw_running:
                             self.current_command_id = result_command_id

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -559,6 +559,46 @@ class KachakaApiClientByZenoh:
             return True
         return isinstance(command_dict, dict) and expected_field in command_dict
 
+    def _observed_move_target_matches_dispatch(self, command_dict: Optional[Dict[str, Any]]) -> bool:
+        """Return True when an observed moveToPoseCommand's own target matches what we dispatched.
+
+        Type match alone cannot distinguish our own move_to_pose from a
+        same-type command started by someone else (or a stale one):
+        Kachaka's async StartCommand never returns commandId synchronously
+        (KachakaApiClient.start_command discards it when wait_for_completion
+        is False), so before a command_id is bound, only the observed
+        command's own x/y/yaw -- not just its type -- can confirm it is the
+        command we just sent (Codex re-review ISS34-010 blocking-2, Issue
+        #34 Plan §7.3). When command_target_pose was not set (dispatch did
+        not go through the move_to_pose branch), there is nothing to compare
+        against and the check is skipped so type-only matching still applies.
+        """
+        if self.command_target_pose is None:
+            return True
+        if not isinstance(command_dict, dict):
+            return False
+        observed = command_dict.get('moveToPoseCommand')
+        if not isinstance(observed, dict):
+            return False
+        distance = math.hypot(
+            observed.get('x', 0.0) - self.command_target_pose.x,
+            observed.get('y', 0.0) - self.command_target_pose.y,
+        )
+        yaw_diff = abs(self._normalize_angle(observed.get('yaw', 0.0) - self.command_target_pose.theta))
+        return distance <= self.command_match_distance_tolerance and yaw_diff <= self.command_match_yaw_tolerance
+
+    def _observed_command_confirmed_for_bind(self, command_dict: Optional[Dict[str, Any]]) -> bool:
+        """Return True when an observed command can be confirmed as the one we dispatched.
+
+        Combines the type-match gate with the move_to_pose target check so
+        every command_id-binding call site rejects a same-type command that
+        cannot be confirmed as ours, rather than binding on type alone
+        (Codex re-review ISS34-010 blocking-2, Issue #34 Plan §7.3).
+        """
+        if not self._observed_command_type_matches_expected(command_dict):
+            return False
+        return self._observed_move_target_matches_dispatch(command_dict)
+
     def _record_motion_progress_baseline(self) -> None:
         """Reset the motion_progress baseline to the current pose and time."""
         self._motion_progress_pose = self.last_pose
@@ -965,12 +1005,14 @@ class KachakaApiClientByZenoh:
 
                 if self.is_async_command:
                     if (self.current_command_id is None and self._is_running_state(state_value) and
-                            not self._observed_command_type_matches_expected(command_dict)):
-                        # A RUNNING command of the wrong type must never be bound to
-                        # this task, even before any command_id has been bound
-                        # (Issue #34 Plan §7.3, Codex review ISS34-006 blocking finding).
+                            not self._observed_command_confirmed_for_bind(command_dict)):
+                        # A RUNNING command that cannot be confirmed as ours (wrong
+                        # type, or for move_to_pose a mismatched target) must never
+                        # be bound to this task, even before any command_id has been
+                        # bound (Issue #34 Plan §7.3, Codex review ISS34-006/ISS34-010
+                        # blocking findings).
                         self.logger.debug(
-                            'Ignoring RUNNING command_id %s for task %s: type mismatch (expected %s)',
+                            'Ignoring RUNNING command_id %s for task %s: not confirmed as ours (expected %s)',
                             command_id,
                             self.task_id,
                             self.expected_kachaka_method,
@@ -1011,7 +1053,7 @@ class KachakaApiClientByZenoh:
 
                 if self.is_async_command and not self.saw_running:
                     if (self.current_command_id is None and command_id and self._running_state_wait_expired() and
-                            self._observed_command_type_matches_expected(command_dict)):
+                            self._observed_command_confirmed_for_bind(command_dict)):
                         self.current_command_id = command_id
                         self._log_warning(f'RUNNING state was not observed within {self.running_state_wait}s; '
                                           f'falling back to command_id={command_id} for task {self.task_id}')
@@ -1028,9 +1070,9 @@ class KachakaApiClientByZenoh:
 
                 if self.is_async_command:
                     if (self.current_command_id is None and self.saw_running and result_command_id and
-                            not self._observed_command_type_matches_expected(result_command_dict)):
+                            not self._observed_command_confirmed_for_bind(result_command_dict)):
                         self._log_warning(f'Ignoring result command_id {result_command_id} for task {self.task_id}: '
-                                          f'type mismatch (expected {self.expected_kachaka_method})')
+                                          f'not confirmed as ours (expected {self.expected_kachaka_method})')
                         return
                     if result_command_id:
                         if self.current_command_id is None and self.saw_running:
@@ -1089,6 +1131,7 @@ class KachakaApiClientByZenoh:
                 # Publish and reset
                 self.last_command_result = result
                 if self._publish_to_zenoh(self.command_is_completed_pub, result.as_payload()) and result.is_completed:
+                    self._record_own_return_home_retention()
                     self._reset_async_command_state()
 
         except RpcError as e:
@@ -1733,6 +1776,23 @@ class KachakaApiClientByZenoh:
             self._publish_command_completion(success=False, error_code=-1, task_id=task_id)
             raise
 
+    def _record_own_return_home_retention(self) -> None:
+        """Remember a completing dock's command_id for the ownership grace period.
+
+        Must run on every completion path immediately before
+        _reset_async_command_state() clears current_command_id, not only
+        the explicit _publish_command_completion() path: publish_result()'s
+        normal async-success completion calls _reset_async_command_state()
+        directly and previously bypassed this recording entirely, so
+        _is_own_return_home() had no record to recognize a briefly-lingering
+        RUNNING return_home right after an ordinary dock success (Issue #34
+        Plan §7.4 concern (b), Codex re-review ISS34-010 recommendation-2).
+        """
+        if (self.last_command is not None and self.last_command.get('method') == 'dock' and
+                self.current_command_id is not None):
+            self._recently_own_return_home_id = self.current_command_id
+            self._recently_own_return_home_until = time.monotonic() + self.own_return_home_retention
+
     def _reset_async_command_state(self) -> None:
         """Reset all async command tracking state.
 
@@ -1830,15 +1890,7 @@ class KachakaApiClientByZenoh:
 
             # Clear all async command tracking state after publishing
             if target_task_id == self.task_id:
-                if (self.last_command is not None and self.last_command.get('method') == 'dock' and
-                        self.current_command_id is not None):
-                    # Issue #34 Plan §7.4 concern (b): Kachaka can still report a
-                    # brief lingering RUNNING return_home right after this dock
-                    # completes; remember its id for a short grace period so it
-                    # is not mistaken for an external returnHome once task_id is
-                    # cleared below.
-                    self._recently_own_return_home_id = self.current_command_id
-                    self._recently_own_return_home_until = time.monotonic() + self.own_return_home_retention
+                self._record_own_return_home_retention()
                 self._reset_async_command_state()
             return True
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -20,6 +20,7 @@ import asyncio
 from dataclasses import dataclass
 import json
 import logging
+import math
 import os
 from pathlib import Path
 import threading
@@ -54,29 +55,36 @@ class Pose:
 class CommandCompletion:
     """Internal command completion state.
 
-    as_payload() publishes {id, is_completed, success} to Zenoh.
+    as_payload() publishes {id, is_completed, success, reason} to Zenoh.
     error_code is kept on the instance for the Kachaka-side retry logic
-    but is NOT published — see as_payload().
+    but is NOT published — see as_payload(). reason IS published (it is an
+    optional field existing consumers can ignore, see Issue #34 Plan §5.2).
 
     error_code values used internally (not transmitted):
         0   : success
         -1  : unknown / format error
-        -2  : map name mismatch
+        -2  : map name mismatch (reason='map_mismatch')
         -3  : superseded by a new command
         -4  : gRPC channel persistently stuck (Deadline Exceeded > grpc_stuck threshold)
         -5  : completion watchdog expired (no RUNNING/completion observed in time)
+        -6  : no RUNNING observed within command_start timeout (reason='start_timeout')
+        -7  : no motion progress within motion_progress timeout (reason='progress_timeout')
+        -8  : preempted by an externally-triggered returnHome (reason='external_preempted')
+        -9  : rejected while external control is active (reason='external_busy')
     """
 
     task_id: str
     is_completed: bool
     success: Optional[bool]
     error_code: Optional[int]
+    reason: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not self.task_id:
             raise ValueError('task_id must not be empty')
-        if not self.is_completed and (self.success is not None or self.error_code is not None):
-            raise ValueError('in-progress completion must not have success or error_code')
+        if not self.is_completed and (self.success is not None or self.error_code is not None or
+                                      self.reason is not None):
+            raise ValueError('in-progress completion must not have success, error_code or reason')
 
     def as_payload(self) -> Dict[str, Any]:
         """Return the payload for Zenoh publishing.
@@ -89,6 +97,8 @@ class CommandCompletion:
         }
         if self.is_completed and self.success is not None:
             payload['success'] = self.success
+        if self.is_completed and self.reason is not None:
+            payload['reason'] = self.reason
         return payload
 
 
@@ -145,10 +155,33 @@ class KachakaApiClientByZenoh:
     retry_interval: float
     retry_on_error_types: List[str]
     retry_count: int
+    state_pub: zenoh.Publisher
+    noop_distance_tolerance: float
+    noop_yaw_tolerance: float
+    progress_distance_delta: float
+    progress_yaw_delta: float
+    command_match_distance_tolerance: float
+    command_match_yaw_tolerance: float
+    command_start_timeout: float
+    motion_progress_timeout: float
+    command_dispatched_at: Optional[float]
+    expected_kachaka_method: Optional[str]
+    command_target_map_name: Optional[str]
+    command_target_pose: Optional[Pose]
+    external_control_active: bool
 
     # Consecutive command_id mismatches tolerated before undoing a binding
     # (one mismatch is observed roughly once per main loop iteration).
     MAX_IGNORED_MISMATCHES = 5
+
+    # Maps the internal (post method_mapping) Kachaka method name to the
+    # protobuf Command oneof field MessageToDict() produces, used by
+    # _validate_command_match() to confirm a result actually belongs to the
+    # command type that was dispatched (Issue #34 Plan §7.3).
+    COMMAND_TYPE_FIELD = {
+        'move_to_pose': 'moveToPoseCommand',
+        'return_home': 'returnHomeCommand',
+    }
 
     def __init__(
         self,
@@ -187,6 +220,7 @@ class KachakaApiClientByZenoh:
         intervals = config.get('intervals', {})
         connection = config.get('connection', {})
         navigation_retry = config.get('navigation_retry', {})
+        navigation = config.get('navigation', {})
 
         self.command_query_timeout = timeouts.get('command_query', 2.0)
         self.grpc_connection_sleep = timeouts.get('grpc_connection', 5)
@@ -195,7 +229,17 @@ class KachakaApiClientByZenoh:
         self.grpc_status_check_timeout = timeouts.get('grpc_status_check', 5.0)
         self.grpc_stuck_threshold = float(timeouts.get('grpc_stuck', 30.0))
         self.command_completion_timeout = float(timeouts.get('command_completion', 180.0))
+        self.command_start_timeout = float(timeouts.get('command_start', 15.0))
+        self.motion_progress_timeout = float(timeouts.get('motion_progress', 30.0))
         self.command_check_interval = intervals.get('command_check', 4.0)
+
+        # Load navigation tolerance settings (Issue #34 Plan §7.1-§7.3)
+        self.noop_distance_tolerance = float(navigation.get('noop_distance_tolerance', 0.15))
+        self.noop_yaw_tolerance = float(navigation.get('noop_yaw_tolerance', 0.10))
+        self.progress_distance_delta = float(navigation.get('progress_distance_delta', 0.02))
+        self.progress_yaw_delta = float(navigation.get('progress_yaw_delta', 0.02))
+        self.command_match_distance_tolerance = float(navigation.get('command_match_distance_tolerance', 0.75))
+        self.command_match_yaw_tolerance = float(navigation.get('command_match_yaw_tolerance', 0.35))
         self.main_loop_sleep = intervals.get('main_loop', 1)
         self.max_retries = connection.get('max_retries', 20)
         self.command_max_retries = connection.get('command_max_retries', 2)
@@ -226,6 +270,7 @@ class KachakaApiClientByZenoh:
         self.map_name_pub = self.session.declare_publisher(f'robots/{self.robot_name}/map_name')
         self.command_is_completed_pub = self.session.declare_publisher(
             f'robots/{self.robot_name}/command_is_completed')
+        self.state_pub = self.session.declare_publisher(f'robots/{self.robot_name}/state')
 
         # Initialize queryable for request-reply pattern
         self.status_queryable = self.session.declare_queryable(f'robots/{self.robot_name}/status',
@@ -265,6 +310,27 @@ class KachakaApiClientByZenoh:
         # Consecutive polls whose state/result command_id mismatched the bound
         # current_command_id; used to detect and undo a wrong binding.
         self._ignored_result_count = 0
+        # Monotonic dispatch time of the active async command; drives the
+        # command_start timeout (RUNNING must be observed before it expires).
+        self.command_dispatched_at: Optional[float] = None
+        # Pose baseline and timestamp for the motion_progress timeout: reset
+        # whenever the robot's position/yaw moves beyond the configured delta
+        # while RUNNING, so a stalled-in-place RUNNING command still times out.
+        self._motion_progress_pose: Optional[Pose] = None
+        self._motion_progress_at: Optional[float] = None
+        # Expected Kachaka command type/target for the active async command,
+        # used to confirm a success result actually matches what was
+        # dispatched (Issue #34 Plan §7.3).
+        self.expected_kachaka_method: Optional[str] = None
+        self.command_target_map_name: Optional[str] = None
+        self.command_target_pose: Optional[Pose] = None
+        # True while an externally-triggered returnHome (not issued by this
+        # bridge) is observed running on the robot (Issue #34 Plan §7.4).
+        self.external_control_active = False
+        self._external_command_id: Optional[str] = None
+        # Monotonically increasing sequence number for the unified state
+        # payload (Issue #34 Plan §5.1).
+        self._state_seq = 0
 
     def _get_zenoh_config(self, zenoh_router: str) -> zenoh.Config:
         """Get Zenoh configuration with the provided router.
@@ -431,6 +497,190 @@ class KachakaApiClientByZenoh:
                 self.current_command_id,
             )
 
+    @staticmethod
+    def _normalize_angle(angle: float) -> float:
+        """Normalize an angle (radians) to (-pi, pi], wrapping across the +/-pi seam."""
+        return math.atan2(math.sin(angle), math.cos(angle))
+
+    def _is_near_target(
+        self,
+        target_x: float,
+        target_y: float,
+        target_yaw: float,
+        distance_tolerance: float,
+        yaw_tolerance: float,
+    ) -> bool:
+        """Return True when the last known pose is within tolerance of the target.
+
+        Used both for the near-distance short-circuit (§7.1, noop_* tolerances)
+        and to confirm a Kachaka success actually reached the RMF-requested
+        target (§7.3, command_match_* tolerances).
+        """
+        distance = math.hypot(target_x - self.last_pose.x, target_y - self.last_pose.y)
+        yaw_diff = abs(self._normalize_angle(target_yaw - self.last_pose.theta))
+        return distance <= distance_tolerance and yaw_diff <= yaw_tolerance
+
+    def _record_motion_progress_baseline(self) -> None:
+        """Reset the motion_progress baseline to the current pose and time."""
+        self._motion_progress_pose = self.last_pose
+        self._motion_progress_at = time.monotonic()
+
+    def _check_motion_progress(self) -> None:
+        """Advance the motion_progress baseline if the pose moved beyond the configured delta.
+
+        Called every cycle the active command is RUNNING. Only a real
+        position/yaw change counts as progress; observing RUNNING alone does
+        not (Issue #34 Plan §7.2).
+        """
+        if self._motion_progress_pose is None:
+            self._record_motion_progress_baseline()
+            return
+        if not self._is_near_target(
+                self._motion_progress_pose.x,
+                self._motion_progress_pose.y,
+                self._motion_progress_pose.theta,
+                distance_tolerance=self.progress_distance_delta,
+                yaw_tolerance=self.progress_yaw_delta,
+        ):
+            self._record_motion_progress_baseline()
+
+    def _command_start_timeout_expired(self) -> bool:
+        """Return True when RUNNING has not been observed within command_start_timeout."""
+        if self.command_dispatched_at is None:
+            return False
+        return (time.monotonic() - self.command_dispatched_at) >= self.command_start_timeout
+
+    def _motion_progress_timeout_expired(self) -> bool:
+        """Return True when the pose has not moved within motion_progress_timeout while RUNNING."""
+        if self._motion_progress_at is None:
+            return False
+        return (time.monotonic() - self._motion_progress_at) >= self.motion_progress_timeout
+
+    def _attempt_cancel_active_command(self) -> None:
+        """Best-effort cancel of the active Kachaka command on a start/progress timeout."""
+        try:
+            if hasattr(self.kachaka_client, 'cancel_command'):
+                self.kachaka_client.cancel_command()
+        except Exception as e:
+            self._log_error('Unexpected', '_attempt_cancel_active_command', e)
+
+    def _handle_async_timeout(self, error_code: int, reason: str) -> None:
+        """Cancel and fail-once the active async command on a start/progress timeout."""
+        task_id = self.task_id
+        if not task_id:
+            return
+        self._log_error_msg(f'{reason} for task {task_id}; attempting cancel and failing once')
+        self._attempt_cancel_active_command()
+        self._publish_command_completion(success=False, error_code=error_code, task_id=task_id, reason=reason)
+
+    def _validate_command_match(self, last_result: Dict[str, Any]) -> tuple:
+        """Confirm a Kachaka success result matches the command that was dispatched.
+
+        A matching command_id is not sufficient: the Kachaka command type,
+        current floor, and (when applicable) target position/yaw must also
+        match, so a same-ID-but-different-command success is never reported
+        as the active RMF instruction's success (Issue #34 Plan §7.3).
+
+        Returns:
+            (matched, reason): matched is False when the result should not be
+                treated as success; reason is the Plan §5.2 reason string to
+                publish, or None when no listed reason applies.
+        """
+        expected_field = self.COMMAND_TYPE_FIELD.get(self.expected_kachaka_method or '')
+        if expected_field is None:
+            return True, None
+
+        command_dict = last_result.get('command')
+        if not isinstance(command_dict, dict) or expected_field not in command_dict:
+            self._log_warning(
+                f'Command type mismatch for task {self.task_id}: expected {expected_field}, got {command_dict!r}')
+            return False, None
+
+        if (self.command_target_map_name is not None and
+                self.command_target_map_name != self.map_state.telemetry_map_name):
+            self._log_warning(f'Floor mismatch at completion for task {self.task_id}: expected '
+                              f'{self.command_target_map_name}, robot is on {self.map_state.telemetry_map_name}')
+            return False, 'map_mismatch'
+
+        if self.command_target_pose is not None and not self._is_near_target(
+                self.command_target_pose.x,
+                self.command_target_pose.y,
+                self.command_target_pose.theta,
+                distance_tolerance=self.command_match_distance_tolerance,
+                yaw_tolerance=self.command_match_yaw_tolerance,
+        ):
+            self._log_warning(f'Target position mismatch at completion for task {self.task_id}: '
+                              f'target={self.command_target_pose.as_list()}, last_pose={self.last_pose.as_list()}')
+            return False, None
+
+        return True, None
+
+    def _is_own_return_home(self, observed_command_id: Optional[str]) -> bool:
+        """Return True when a RUNNING returnHomeCommand belongs to our own dispatched dock.
+
+        RMF issues return_home via the 'dock' RMF method (mapped to Kachaka's
+        return_home). Before the command_id has been bound (early in the
+        dispatch), the observed id cannot yet be compared, so any RUNNING
+        return_home while our own dock task is in flight is treated as ours
+        (Issue #34 Plan §7.4).
+        """
+        if self.task_id is None or self.last_command is None:
+            return False
+        if self.last_command.get('method') != 'dock':
+            return False
+        return self.current_command_id is None or self.current_command_id == observed_command_id
+
+    def _handle_external_return_home_started(self, command_id: Optional[str]) -> None:
+        """Preempt any active RMF task and mark external control as active."""
+        preempted_task_id = self.task_id
+        if preempted_task_id is not None:
+            self._log_error_msg(f'External returnHome (command_id={command_id}) observed; '
+                                f'preempting active RMF task {preempted_task_id}')
+            self._publish_command_completion(success=False,
+                                             error_code=-8,
+                                             task_id=preempted_task_id,
+                                             reason='external_preempted')
+        else:
+            self._log_info(f'External returnHome (command_id={command_id}) observed while idle')
+        self.external_control_active = True
+        self._external_command_id = command_id
+
+    def _handle_external_return_home_ended(self) -> None:
+        """Mark external control as no longer active."""
+        self._log_info(f'External returnHome (command_id={self._external_command_id}) ended')
+        self.external_control_active = False
+        self._external_command_id = None
+
+    async def monitor_external_control(self) -> None:
+        """Detect Kachaka commands not issued by this bridge (Issue #34 Plan §7.4).
+
+        Runs every main loop iteration regardless of whether an RMF task is
+        active, so an externally-triggered returnHome (e.g. from the Kachaka
+        app or a low-battery auto-return) is observed even while idle.
+        """
+        method_name = 'monitor_external_control'
+        try:
+            state_res = self._get_command_state_response()
+        except RpcError:
+            return  # Already logged by _get_command_state_response.
+        except Exception as e:
+            self._log_error('Unexpected', method_name, e)
+            return
+
+        with self._command_lock:
+            command_dict = state_res.get('command')
+            is_return_home = isinstance(command_dict, dict) and 'returnHomeCommand' in command_dict
+            is_running = self._is_running_state(state_res.get('state'))
+            observed_id = state_res.get('commandId')
+
+            is_external_now = (is_return_home and is_running and observed_id is not None and
+                               not self._is_own_return_home(observed_id))
+
+            if is_external_now and not self.external_control_active:
+                self._handle_external_return_home_started(observed_id)
+            elif not is_external_now and self.external_control_active:
+                self._handle_external_return_home_ended()
+
     async def publish_pose(self) -> None:
         """Publish the current robot pose to Zenoh.
 
@@ -523,6 +773,55 @@ class KachakaApiClientByZenoh:
         except Exception as e:
             self._log_error('Unexpected', method_name, e)
 
+    async def publish_state(self) -> None:
+        """Publish the unified robot state payload to Zenoh (Issue #34 Plan §5.1).
+
+        Kachaka has no API that returns floor and position atomically, so this
+        reads floor -> pose -> floor and only publishes when both floor reads
+        agree; a switch_map racing this read is caught by the mismatch and the
+        sample is discarded rather than published with a stale floor/pose
+        combination. On any gRPC error the sample is discarded outright: an
+        old pose must never be resent under a new timestamp.
+        """
+        method_name = 'publish_state'
+        try:
+            map_name_before = self._fetch_robot_map_name(self.grpc_telemetry_timeout)
+            pose_response = self.kachaka_client.stub.GetRobotPose(pb2.GetRequest(),
+                                                                  timeout=self.grpc_telemetry_timeout)
+            pose = Pose(pose_response.pose.x, pose_response.pose.y, pose_response.pose.theta)
+            map_name_after = self._fetch_robot_map_name(self.grpc_telemetry_timeout)
+
+            if map_name_before != map_name_after:
+                self.logger.info(
+                    'Discarding state sample: map changed during read (%s -> %s), likely switch_map in progress',
+                    map_name_before,
+                    map_name_after,
+                )
+                return
+
+            with self._command_lock:
+                self._state_seq += 1
+                seq = self._state_seq
+                external_control_active = self.external_control_active
+
+            state_payload = {
+                'schema_version': 1,
+                'seq': seq,
+                'stamp': time.time(),
+                'map_name': map_name_after,
+                'pose': pose.as_list(),
+                'external_control_active': external_control_active,
+            }
+            self._publish_to_zenoh(self.state_pub, state_payload)
+            self.logger.debug(f'Published state seq={seq} map_name={map_name_after}')
+        except RpcError as e:
+            if e.code() == StatusCode.DEADLINE_EXCEEDED:
+                self.logger.warning(f'Timeout in {method_name}; discarding sample (no stale resend)')
+            else:
+                self._log_error('RPC', method_name, e)
+        except Exception as e:
+            self._log_error('Unexpected', method_name, e)
+
     async def _handle_command_retry(self, task_id: str, error_code: int) -> bool:
         """Handle retry logic for failed commands.
 
@@ -604,6 +903,10 @@ class KachakaApiClientByZenoh:
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
 
+                if self.is_async_command and not self.saw_running and self._command_start_timeout_expired():
+                    self._handle_async_timeout(error_code=-6, reason='start_timeout')
+                    return
+
                 if self.is_async_command:
                     if command_id:
                         if self.current_command_id is None and self._is_running_state(state_value):
@@ -624,6 +927,10 @@ class KachakaApiClientByZenoh:
                     self.saw_running = True
                     self.last_progress_at = time.monotonic()
                     self._ignored_result_count = 0
+                    self._check_motion_progress()
+                    if self._motion_progress_timeout_expired():
+                        self._handle_async_timeout(error_code=-7, reason='progress_timeout')
+                        return
                     result = CommandCompletion(
                         task_id=self.task_id,
                         is_completed=False,
@@ -673,11 +980,19 @@ class KachakaApiClientByZenoh:
                 else:
                     success = cmd_result.get('success', False)
                     error_code = cmd_result.get('errorCode', 0)
+                    reason = None
+                    if success and self.is_async_command:
+                        matched, mismatch_reason = self._validate_command_match(last_result)
+                        if not matched:
+                            success = False
+                            error_code = -2 if mismatch_reason == 'map_mismatch' else -1
+                            reason = mismatch_reason
                     result = CommandCompletion(
                         task_id=self.task_id,
                         is_completed=True,
                         success=success,
                         error_code=error_code,
+                        reason=reason,
                     )
 
                     if success:
@@ -943,7 +1258,7 @@ class KachakaApiClientByZenoh:
             self._log_error('RPC', '_verify_map_for_navigation', e)
             self._log_warning(
                 f'Could not verify current map for navigation to {requested_map_name}. Rejecting navigation command.')
-            self._publish_command_completion(success=False, error_code=-2, task_id=task_id)
+            self._publish_command_completion(success=False, error_code=-2, task_id=task_id, reason='map_mismatch')
             return False
 
         self.map_state = self.map_state.with_telemetry_map_name(current_map_name)
@@ -959,7 +1274,7 @@ class KachakaApiClientByZenoh:
         self._log_warning(f'Map name mismatch: requested={requested_map_name}, '
                           f'current={current_map_name}. '
                           f'Rejecting navigation command to prevent navigation to wrong floor coordinates.')
-        self._publish_command_completion(success=False, error_code=-2, task_id=task_id)
+        self._publish_command_completion(success=False, error_code=-2, task_id=task_id, reason='map_mismatch')
         return False
 
     def _execute_command(self, command: Dict[str, Any], expected_task_id: Optional[str] = None) -> None:
@@ -993,6 +1308,14 @@ class KachakaApiClientByZenoh:
                     new_task_id = command.get('id', None) if isinstance(command, dict) else None
                     if not isinstance(command, dict) or not all(k in command for k in ('method', 'args')):
                         raise ValueError('Invalid command structure')
+                    if self.external_control_active:
+                        self._log_warning(
+                            f'External control active; rejecting RMF command {new_task_id} with external_busy')
+                        self._publish_command_completion(success=False,
+                                                         error_code=-9,
+                                                         task_id=new_task_id,
+                                                         reason='external_busy')
+                        return
                     if expected_task_id is not None and self.task_id != expected_task_id:
                         self.logger.debug('Skip dispatch for stale task %s (active task: %s)', expected_task_id,
                                           self.task_id)
@@ -1028,6 +1351,12 @@ class KachakaApiClientByZenoh:
                     self.saw_running = False
                     self.async_command_started_at = None
                     self.last_progress_at = time.monotonic()
+                    self.command_dispatched_at = time.monotonic()
+                    self._motion_progress_pose = None
+                    self._motion_progress_at = None
+                    self.expected_kachaka_method = None
+                    self.command_target_map_name = None
+                    self.command_target_pose = None
                     self._ignored_result_count = 0
                     if not is_retry:
                         self.retry_count = 0
@@ -1042,6 +1371,24 @@ class KachakaApiClientByZenoh:
                         map_name = args.pop('map_name', None)
                         if map_name is not None and not self._verify_map_for_navigation(map_name, new_task_id):
                             return
+                        target_x = args.get('x')
+                        target_y = args.get('y')
+                        target_yaw = args.get('yaw', 0.0)
+                        if (target_x is not None and target_y is not None and self._is_near_target(
+                                target_x,
+                                target_y,
+                                target_yaw,
+                                distance_tolerance=self.noop_distance_tolerance,
+                                yaw_tolerance=self.noop_yaw_tolerance,
+                        )):
+                            self._log_info(
+                                f'Target within noop tolerance (distance<={self.noop_distance_tolerance}m, '
+                                f'yaw<={self.noop_yaw_tolerance}rad); reporting success without calling Kachaka')
+                            self._publish_command_completion(success=True, error_code=0, task_id=new_task_id)
+                            return
+                        self.expected_kachaka_method = 'move_to_pose'
+                        self.command_target_map_name = map_name
+                        self.command_target_pose = Pose(target_x or 0.0, target_y or 0.0, target_yaw or 0.0)
                         args = self._prepare_async_command_args(args, {'cancel_all': True})
                         self.logger.debug(f'Current pose: {self.last_pose.as_list()}')
                         self.logger.debug(f'Target pose: x={args.get("x")}, y={args.get("y")}, yaw={args.get("yaw")}')
@@ -1049,6 +1396,7 @@ class KachakaApiClientByZenoh:
                         if self.is_async_command:
                             self._update_current_command_id(response, method_name)
                     elif method_name == 'return_home':
+                        self.expected_kachaka_method = 'return_home'
                         args = self._prepare_async_command_args(command['args'])
                         response = self._execute_sync_method(method_name, args, task_id=new_task_id)
                         if self.is_async_command:
@@ -1305,6 +1653,12 @@ class KachakaApiClientByZenoh:
         self.async_command_started_at = None
         self.last_progress_at = None
         self._ignored_result_count = 0
+        self.command_dispatched_at = None
+        self._motion_progress_pose = None
+        self._motion_progress_at = None
+        self.expected_kachaka_method = None
+        self.command_target_map_name = None
+        self.command_target_pose = None
 
     def _reconstruct_kachaka_client(self) -> bool:
         """Recreate the KachakaApiClient to recover from a dead gRPC channel.
@@ -1331,7 +1685,13 @@ class KachakaApiClientByZenoh:
                 self._log_error('Unexpected', '_reconstruct_kachaka_client', e)
                 return False
 
-    def _publish_command_completion(self, success: bool, error_code: int, task_id: Optional[str] = None) -> bool:
+    def _publish_command_completion(
+        self,
+        success: bool,
+        error_code: int,
+        task_id: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> bool:
         """Publish command completion status to Zenoh.
 
         Idempotent per task: when a completion for the same task ID was
@@ -1346,6 +1706,9 @@ class KachakaApiClientByZenoh:
             error_code (int): The error code (0 if success)
             task_id (str, optional): Explicit task ID to publish for.
                 Defaults to the active task.
+            reason (str, optional): Issue #34 Plan §5.2 completion reason
+                (e.g. 'start_timeout', 'external_preempted'). Omitted from
+                the payload when None.
         """
         with self._command_lock:
             target_task_id = task_id if task_id is not None else self.task_id
@@ -1362,6 +1725,7 @@ class KachakaApiClientByZenoh:
                 is_completed=True,
                 success=success,
                 error_code=error_code,
+                reason=reason,
             )
 
             self.last_command_result = completion_result
@@ -1477,6 +1841,8 @@ def main() -> None:
                     node.publish_pose,
                     node.publish_battery,
                     node.publish_map_name,
+                    node.monitor_external_control,
+                    node.publish_state,
                     node.publish_result,
                 ]
                 any_success = False

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -71,6 +71,9 @@ class CommandCompletion:
         -7  : no motion progress within motion_progress timeout (reason='progress_timeout')
         -8  : preempted by an externally-triggered returnHome (reason='external_preempted')
         -9  : rejected while external control is active (reason='external_busy')
+        -10 : StartCommand succeeded but returned no command_id, so ownership
+              could not be captured; fail closed instead of binding by
+              command type/target (reason='missing_command_id')
     """
 
     task_id: str
@@ -322,6 +325,14 @@ class KachakaApiClientByZenoh:
         # publish_result skips polling then, so it can never pair the previous
         # command's result with the task being dispatched.
         self.dispatching = False
+        # commandId of a RUNNING command monitor_external_control() observed
+        # while dispatching=True deferred judgment (Issue #34 Plan §5
+        # "remember snapshot.commandId for reconciliation"): reconciled once
+        # the dispatch settles, so a genuinely external command that both
+        # starts and ends entirely within the dispatch window is still
+        # detected instead of silently missed (Codex re-review ISS34-037
+        # non-blocking finding).
+        self._pending_dispatch_snapshot_id: Optional[str] = None
         # Monotonic time of last observed progress (accept or RUNNING) for the
         # active task; drives the completion watchdog.
         self.last_progress_at: Optional[float] = None
@@ -474,15 +485,14 @@ class KachakaApiClientByZenoh:
         return False
 
     def _update_current_command_id(self, response: Optional[Dict[str, Any]], method_name: str) -> None:
-        """Extract and store command_id for async commands if available."""
-        if not isinstance(response, dict):
-            return
-        command_id = response.get('commandId')
-        if command_id:
-            self.current_command_id = command_id
-            self.logger.debug(f'Captured command_id {command_id} for {method_name}')
-        else:
-            self.logger.warning(f'Async command {method_name} did not return commandId; awaiting state update')
+        """Bind current_command_id from a StartCommand response known to carry a non-empty commandId.
+
+        Callers must already have fail-closed a missing/empty commandId
+        (Codex re-review ISS34-037 blocking-1); this only performs the bind.
+        """
+        command_id = response.get('commandId') if isinstance(response, dict) else None
+        self.current_command_id = command_id
+        self.logger.debug(f'Captured command_id {command_id} for {method_name}')
 
     def _running_state_wait_expired(self) -> bool:
         """Return True when waiting for RUNNING has exceeded the configured timeout."""
@@ -578,69 +588,18 @@ class KachakaApiClientByZenoh:
     def _observed_command_type_matches_expected(self, command_dict: Optional[Dict[str, Any]]) -> bool:
         """Return True when an observed Kachaka command payload's type matches expected_kachaka_method.
 
-        Used to gate the first bind of current_command_id (Issue #34 Plan
-        §7.3): a RUNNING/result command of the wrong type must never be bound
-        to the active RMF task, even before any command_id has been bound.
+        Used by _validate_command_match() to confirm a completed command's
+        type actually matches what was dispatched before its success is
+        reported to RMF (Issue #34 Plan §7.3). Ownership (which command_id
+        this task's polling should follow) is decided solely by command_id
+        equality against the id captured at dispatch (Codex re-review
+        ISS34-037 blocking-1) -- command type/target are never used to bind
+        an unconfirmed command_id.
         """
         expected_field = self.COMMAND_TYPE_FIELD.get(self.expected_kachaka_method or '')
         if expected_field is None:
             return True
         return isinstance(command_dict, dict) and expected_field in command_dict
-
-    def _observed_move_target_matches_dispatch(self, command_dict: Optional[Dict[str, Any]]) -> bool:
-        """Return True when an observed moveToPoseCommand's own target matches what we dispatched.
-
-        Type match alone cannot distinguish our own move_to_pose from a
-        same-type command started by someone else (or a stale one):
-        Kachaka's async StartCommand never returns commandId synchronously
-        (KachakaApiClient.start_command discards it when wait_for_completion
-        is False), so before a command_id is bound, only the observed
-        command's own x/y/yaw -- not just its type -- can confirm it is the
-        command we just sent (Codex re-review ISS34-010 blocking-2, Issue
-        #34 Plan §7.3). When command_target_pose was not set (dispatch did
-        not go through the move_to_pose branch), there is nothing to compare
-        against and the check is skipped so type-only matching still applies.
-        """
-        if self.command_target_pose is None:
-            return True
-        if not isinstance(command_dict, dict):
-            return False
-        observed = command_dict.get('moveToPoseCommand')
-        if not isinstance(observed, dict):
-            return False
-        distance = math.hypot(
-            observed.get('x', 0.0) - self.command_target_pose.x,
-            observed.get('y', 0.0) - self.command_target_pose.y,
-        )
-        yaw_diff = abs(self._normalize_angle(observed.get('yaw', 0.0) - self.command_target_pose.theta))
-        return distance <= self.command_match_distance_tolerance and yaw_diff <= self.command_match_yaw_tolerance
-
-    def _observed_command_confirmed_for_bind(self, command_dict: Optional[Dict[str, Any]]) -> bool:
-        """Return True when an observed command can be confirmed as the one we dispatched.
-
-        Combines the type-match gate with the move_to_pose target check so
-        every command_id-binding call site rejects a same-type command that
-        cannot be confirmed as ours, rather than binding on type alone
-        (Codex re-review ISS34-010 blocking-2, Issue #34 Plan §7.3).
-
-        Residual scope note (ISS34-036): this type/target confirmation is
-        only ever consulted by publish_result()'s first-bind path, reached
-        solely when current_command_id was never captured at dispatch (a
-        successful StartCommand response with no command_id) -- an anomaly
-        the stub-direct dispatch was specifically introduced to eliminate
-        (ISS34-002-fix3), so it should not occur in practice. If it ever
-        does and a same-type/target external command races it, monitor_
-        external_control() still runs first every main loop iteration and
-        polls independently; ownership here is decided by type/target, not
-        by the bounded own-id set _is_own_command_id() uses. Removing this
-        path entirely (fail the task via command_start_timeout instead of
-        ever binding without a captured id) was considered but left out of
-        this change's scope to avoid destabilizing the ISS34-006/ISS34-010
-        binding behavior these type/target checks were reviewed for.
-        """
-        if not self._observed_command_type_matches_expected(command_dict):
-            return False
-        return self._observed_move_target_matches_dispatch(command_dict)
 
     def _record_motion_progress_baseline(self) -> None:
         """Reset the motion_progress baseline to the current pose and time."""
@@ -795,6 +754,30 @@ class KachakaApiClientByZenoh:
         self.external_control_active = False
         self._external_command_id = None
 
+    def _reconcile_pending_dispatch_snapshot(self) -> None:
+        """Reconcile a RUNNING command_id observed while a dispatch was in flight.
+
+        Must be called holding self._command_lock, once a dispatch has fully
+        settled (dispatching just flipped back to False) and StartCommand's
+        response has already been fail-closed or bound. monitor_external_control()
+        defers judgment while dispatching=True and instead remembers the last
+        RUNNING command_id it saw (Issue #34 Plan §5 "remember
+        snapshot.commandId for reconciliation"); check that id against
+        ownership now, using the same rule monitor_external_control() itself
+        uses, so a transient external command that started and ended entirely
+        within the dispatch window (and would therefore be invisible to any
+        later live poll) is still detected rather than silently dropped
+        (Codex re-review ISS34-037 non-blocking finding).
+        """
+        snapshot_id = self._pending_dispatch_snapshot_id
+        self._pending_dispatch_snapshot_id = None
+        if snapshot_id is None or self._is_own_command_id(snapshot_id):
+            return
+        if not self.external_control_active:
+            self._handle_external_command_started(snapshot_id)
+        elif snapshot_id != self._external_command_id:
+            self._external_command_id = snapshot_id
+
     async def monitor_external_control(self) -> None:
         """Detect Kachaka commands not issued by this bridge (Issue #34 Plan §5).
 
@@ -820,6 +803,10 @@ class KachakaApiClientByZenoh:
             return
 
         with self._command_lock:
+            command_dict = state_res.get('command')
+            is_running = self._is_running_state(state_res.get('state'))
+            observed_id = state_res.get('commandId')
+
             if self.dispatching:
                 # A dispatch is in flight and has not yet synchronously bound
                 # its own command_id (_execute_async_stub_dispatch runs the
@@ -828,12 +815,15 @@ class KachakaApiClientByZenoh:
                 # not-yet-bound dispatch as external; defer to the next poll,
                 # by which point the dispatch has either bound
                 # current_command_id or failed and reset task_id (Issue #34
-                # Plan §5 dispatch-pending hold).
+                # Plan §5 dispatch-pending hold). Remember this snapshot so
+                # _reconcile_pending_dispatch_snapshot() can still catch a
+                # genuinely external command once the dispatch settles, even
+                # if it has already ended by the next live poll (Codex
+                # re-review ISS34-037 non-blocking finding).
+                if is_running and observed_id is not None:
+                    self._pending_dispatch_snapshot_id = observed_id
                 return
 
-            command_dict = state_res.get('command')
-            is_running = self._is_running_state(state_res.get('state'))
-            observed_id = state_res.get('commandId')
             is_external_now = is_running and observed_id is not None and not self._is_own_command_id(observed_id)
 
             if is_external_now:
@@ -1074,41 +1064,33 @@ class KachakaApiClientByZenoh:
                 self.logger.debug(f'GetCommandState response: {state_res}')
                 command_id = state_res.get('commandId')
                 state_value = state_res.get('state')
-                command_dict = state_res.get('command') if isinstance(state_res, dict) else None
 
                 if self.is_async_command and not self.saw_running and self._command_start_timeout_expired():
                     self._handle_async_timeout(error_code=-6, reason='start_timeout')
                     return
 
                 if self.is_async_command:
-                    if (self.current_command_id is None and self._is_running_state(state_value) and
-                            not self._observed_command_confirmed_for_bind(command_dict)):
-                        # A RUNNING command that cannot be confirmed as ours (wrong
-                        # type, or for move_to_pose a mismatched target) must never
-                        # be bound to this task, even before any command_id has been
-                        # bound (Issue #34 Plan §7.3, Codex review ISS34-006/ISS34-010
-                        # blocking findings).
+                    if self.current_command_id is None:
+                        # Ownership is bound exclusively by StartCommand's response
+                        # command_id, captured synchronously at dispatch
+                        # (_execute_async_stub_dispatch). A fail-closed dispatch
+                        # (Issue #34 Plan §7.3/§7.4, Codex re-review ISS34-037
+                        # blocking-1) never leaves this unbound while a task is
+                        # active, so reaching here means the invariant was
+                        # violated upstream; never treat an unconfirmed RUNNING
+                        # command as progress on our task in that case (matching
+                        # command type/target used to be accepted as an ownership
+                        # proof here, but a same-type/target external command
+                        # racing an ID-less dispatch could poison it).
                         self.logger.debug(
-                            'Ignoring RUNNING command_id %s for task %s: not confirmed as ours (expected %s)',
-                            command_id,
+                            'Task %s has no bound command_id; ignoring observed command_id %s',
                             self.task_id,
-                            self.expected_kachaka_method,
+                            command_id,
                         )
                         return
-                    if command_id:
-                        if self.current_command_id is None and self._is_running_state(state_value):
-                            self.current_command_id = command_id
-                            self._ignored_result_count = 0
-                            self.logger.debug(f'Bound command_id {command_id} to task {self.task_id}')
-                        elif self.current_command_id and command_id != self.current_command_id:
-                            self._note_ignored_mismatch('command state', command_id)
-                            return
-                    else:
-                        self.logger.debug(
-                            'Command state missing commandId for task %s (state=%s)',
-                            self.task_id,
-                            state_value,
-                        )
+                    if command_id and command_id != self.current_command_id:
+                        self._note_ignored_mismatch('command state', command_id)
+                        return
 
                 if self._is_running_state(state_value):
                     self.saw_running = True
@@ -1128,39 +1110,21 @@ class KachakaApiClientByZenoh:
                     self._publish_to_zenoh(self.command_is_completed_pub, result.as_payload())
                     return
 
-                if self.is_async_command and not self.saw_running:
-                    if (self.current_command_id is None and command_id and self._running_state_wait_expired() and
-                            self._observed_command_confirmed_for_bind(command_dict)):
-                        self.current_command_id = command_id
-                        self._log_warning(f'RUNNING state was not observed within {self.running_state_wait}s; '
-                                          f'falling back to command_id={command_id} for task {self.task_id}')
-                    elif self.current_command_id is None:
-                        self.logger.debug('Async command: waiting to see RUNNING state first')
-                        return
+                if self.is_async_command and not self.saw_running and not self._running_state_wait_expired():
+                    self.logger.debug('Async command: waiting to see RUNNING state first')
+                    return
 
                 last_result = self._get_last_command_result_response()
                 # Both GetCommandState and GetLastCommandResult succeeded; reset stuck timer.
                 self._first_grpc_failure_time = None
                 self.logger.debug(f'GetLastCommandResult response: {last_result}')
                 result_command_id = last_result.get('commandId')
-                result_command_dict = last_result.get('command') if isinstance(last_result, dict) else None
 
-                if self.is_async_command:
-                    if (self.current_command_id is None and self.saw_running and result_command_id and
-                            not self._observed_command_confirmed_for_bind(result_command_dict)):
-                        self._log_warning(f'Ignoring result command_id {result_command_id} for task {self.task_id}: '
-                                          f'not confirmed as ours (expected {self.expected_kachaka_method})')
-                        return
-                    if result_command_id:
-                        if self.current_command_id is None and self.saw_running:
-                            self.current_command_id = result_command_id
-                            self._ignored_result_count = 0
-                            self.logger.debug(f'Bound result command_id {result_command_id} to task {self.task_id}')
-                        elif self.current_command_id and result_command_id != self.current_command_id:
-                            self._note_ignored_mismatch('result', result_command_id)
-                            return
-                    else:
-                        self.logger.debug(f'Last command result missing commandId for task {self.task_id}')
+                if self.is_async_command and result_command_id and result_command_id != self.current_command_id:
+                    self._note_ignored_mismatch('result', result_command_id)
+                    return
+                if self.is_async_command and not result_command_id:
+                    self.logger.debug(f'Last command result missing commandId for task {self.task_id}')
 
                 cmd_result = last_result.get('result')
                 if not isinstance(cmd_result, dict):
@@ -1584,6 +1548,7 @@ class KachakaApiClientByZenoh:
                 finally:
                     with self._command_lock:
                         self.dispatching = False
+                        self._reconcile_pending_dispatch_snapshot()
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
             self._log_error_msg(f'Invalid command: {str(e)}')
             if new_task_id:
@@ -1819,7 +1784,27 @@ class KachakaApiClientByZenoh:
             success = result_dict.get('success', False)
             error_code = result_dict.get('errorCode', 0)
 
-            if success:
+            if success and not response_dict.get('commandId'):
+                # Fail closed instead of leaving current_command_id unbound.
+                # Kachaka API 3.14.4.0's StartCommandResponse normally
+                # carries a non-empty command_id on success, and the
+                # client wrapper itself relies on it; an empty id here is an
+                # anomaly, not routine behavior. The previous design let
+                # publish_result() bind ownership later by matching the
+                # observed command's type/target instead, but a same-
+                # type/target external command racing this dispatch could
+                # bind onto it and have its success misreported as this
+                # task's own (Codex re-review ISS34-037 blocking-1). Never
+                # bind without a captured id; fail the task immediately so
+                # the fleet adapter can retry/replan instead of waiting on
+                # a command we can no longer distinguish from anyone else's.
+                self._log_error_msg(
+                    f'StartCommand for {method_name} succeeded but returned no command_id; failing closed')
+                self._publish_command_completion(success=False,
+                                                 error_code=-10,
+                                                 task_id=task_id,
+                                                 reason='missing_command_id')
+            elif success:
                 # Origin of the command_start timeout is dispatch success
                 # (here), not command acceptance in _execute_command, so a
                 # slow grpc_connection_check above does not eat into the

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -156,6 +156,7 @@ class KachakaApiClientByZenoh:
     retry_on_error_types: List[str]
     retry_count: int
     state_pub: zenoh.Publisher
+    noop_enabled: bool
     noop_distance_tolerance: float
     noop_yaw_tolerance: float
     progress_distance_delta: float
@@ -236,6 +237,7 @@ class KachakaApiClientByZenoh:
         self.command_check_interval = intervals.get('command_check', 4.0)
 
         # Load navigation tolerance settings (Issue #34 Plan §7.1-§7.3)
+        self.noop_enabled = bool(navigation.get('noop_enabled', False))
         self.noop_distance_tolerance = float(navigation.get('noop_distance_tolerance', 0.15))
         self.noop_yaw_tolerance = float(navigation.get('noop_yaw_tolerance', 0.10))
         self.progress_distance_delta = float(navigation.get('progress_distance_delta', 0.02))
@@ -1478,8 +1480,8 @@ class KachakaApiClientByZenoh:
                         # since it is cheap; the fresh floor re-query only happens
                         # for candidates that are otherwise about to short-circuit
                         # (Issue #34 Plan §7.1, Codex review ISS34-006 concern (a)).
-                        if (map_name is not None and target_x is not None and target_y is not None and
-                                self._is_near_target(
+                        if (self.noop_enabled and map_name is not None and target_x is not None and
+                                target_y is not None and self._is_near_target(
                                     target_x,
                                     target_y,
                                     target_yaw,

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -768,6 +768,14 @@ class KachakaApiClientByZenoh:
         within the dispatch window (and would therefore be invisible to any
         later live poll) is still detected rather than silently dropped
         (Codex re-review ISS34-037 non-blocking finding).
+
+        Callers must only invoke this after a dispatch that goes through
+        _execute_async_stub_dispatch() (move_to_pose/return_home): that is
+        the only path that can ever bind current_command_id, which
+        _is_own_command_id() needs to tell "our own in-flight command" apart
+        from a genuinely external one. A sync dispatch (switch_map, etc.)
+        never binds an id at all, so this would always misclassify its own
+        command as external (Codex re-review ISS34-040 blocking-B).
         """
         snapshot_id = self._pending_dispatch_snapshot_id
         self._pending_dispatch_snapshot_id = None
@@ -1088,7 +1096,16 @@ class KachakaApiClientByZenoh:
                             command_id,
                         )
                         return
-                    if command_id and command_id != self.current_command_id:
+                    if command_id != self.current_command_id:
+                        # A required exact match, not just a mismatch check
+                        # when both sides are non-empty: an empty/missing
+                        # commandId here must never be treated as "still
+                        # ours". Kachaka API 3.14.4.0's own client wrapper
+                        # requires result.command_id == response.command_id
+                        # while waiting for completion, so a genuinely
+                        # RUNNING/completed own command is expected to keep
+                        # reporting a non-empty id (Codex re-review
+                        # ISS34-040 blocking-A).
                         self._note_ignored_mismatch('command state', command_id)
                         return
 
@@ -1120,11 +1137,13 @@ class KachakaApiClientByZenoh:
                 self.logger.debug(f'GetLastCommandResult response: {last_result}')
                 result_command_id = last_result.get('commandId')
 
-                if self.is_async_command and result_command_id and result_command_id != self.current_command_id:
+                if self.is_async_command and result_command_id != self.current_command_id:
+                    # Required exact match, same as the state-side check
+                    # above: an empty/missing commandId on the result must
+                    # never be accepted as a completion for our bound
+                    # command (Codex re-review ISS34-040 blocking-A).
                     self._note_ignored_mismatch('result', result_command_id)
                     return
-                if self.is_async_command and not result_command_id:
-                    self.logger.debug(f'Last command result missing commandId for task {self.task_id}')
 
                 cmd_result = last_result.get('result')
                 if not isinstance(cmd_result, dict):
@@ -1502,6 +1521,17 @@ class KachakaApiClientByZenoh:
                     if not is_retry:
                         self.retry_count = 0
                     self.dispatching = True
+                    # Only move_to_pose/return_home go through
+                    # _execute_async_stub_dispatch(), the sole path that can
+                    # ever bind current_command_id from a StartCommand
+                    # response. switch_map and other synchronous methods
+                    # never capture an ownership id at all -- even for their
+                    # own in-flight command -- so a RUNNING snapshot
+                    # observed while one of them dispatches can never be
+                    # confirmed as ours; reconciling it would always
+                    # misclassify the sync command's own id as external
+                    # (Codex re-review ISS34-040 blocking-B).
+                    is_async_dispatch = method_name in ('move_to_pose', 'return_home')
 
                 try:
                     # Heavy gRPC work: outside _command_lock, guarded by dispatching.
@@ -1548,7 +1578,17 @@ class KachakaApiClientByZenoh:
                 finally:
                     with self._command_lock:
                         self.dispatching = False
-                        self._reconcile_pending_dispatch_snapshot()
+                        if is_async_dispatch:
+                            self._reconcile_pending_dispatch_snapshot()
+                        else:
+                            # Discard rather than reconcile: a snapshot from
+                            # a sync dispatch's window has no own id to
+                            # compare against, so reconciling it here could
+                            # only ever misclassify our own command, and
+                            # carrying it over to a later, unrelated async
+                            # dispatch's reconciliation would be equally
+                            # wrong (Codex re-review ISS34-040 blocking-B).
+                            self._pending_dispatch_snapshot_id = None
         except (json.JSONDecodeError, ValueError, AttributeError) as e:
             self._log_error_msg(f'Invalid command: {str(e)}')
             if new_task_id:

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -1426,7 +1426,12 @@ class KachakaApiClientByZenoh:
                     self.saw_running = False
                     self.async_command_started_at = None
                     self.last_progress_at = time.monotonic()
-                    self.command_dispatched_at = time.monotonic()
+                    # Set to the actual dispatch-success time in _execute_sync_method,
+                    # not here: grpc_connection_check can stall before the real send,
+                    # which would otherwise eat into the command_start budget before
+                    # the command was even sent (Issue #34 Plan §7.2, Codex review
+                    # ISS34-006 non-blocking finding).
+                    self.command_dispatched_at = None
                     self._motion_progress_pose = None
                     self._motion_progress_at = None
                     self.expected_kachaka_method = None
@@ -1693,7 +1698,15 @@ class KachakaApiClientByZenoh:
                     # Async command started, don't publish completion yet.
                     # publish_result polls GetCommandState/GetLastCommandResult
                     # and publishes completion after RUNNING state is seen.
-                    self.async_command_started_at = time.monotonic()
+                    now = time.monotonic()
+                    self.async_command_started_at = now
+                    # Origin of the command_start timeout is dispatch success
+                    # (here), not command acceptance in _execute_command, so a
+                    # slow grpc_connection_check above does not eat into the
+                    # budget before the command was actually sent (Issue #34
+                    # Plan §7.2, Codex review ISS34-006 non-blocking finding).
+                    with self._command_lock:
+                        self.command_dispatched_at = now
                     self.logger.info(f'Async command {method_name} started')
                 elif success:
                     self.logger.info(f'Command {method_name} completed successfully')

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -1010,6 +1010,83 @@ def test_external_return_home_when_own_dispatch_never_bound_id_is_detected_as_ex
     assert node.external_control_active is True
 
 
+def test_start_command_success_and_id_bind_are_atomic_under_concurrent_monitor() -> None:
+    """command_dispatched_at/current_command_id must never be observably split across threads.
+
+    Reproduces Codex re-review ISS34-016 blocking-1: _execute_async_stub_dispatch
+    previously set command_dispatched_at/async_command_started_at under
+    _command_lock, but current_command_id was bound afterwards by the caller
+    (_execute_command), outside any lock. A real monitor_external_control()
+    call running on a different thread in that gap saw command_dispatched_at
+    already set but current_command_id still unbound, misclassified our own
+    dispatched dock (return_home) as an external returnHome, and preempted
+    the in-flight task with external_preempted. The fix binds
+    command_dispatched_at/async_command_started_at/current_command_id inside
+    a single _command_lock acquisition in _execute_async_stub_dispatch, so
+    monitor_external_control() can never observe the split state -- it
+    either runs before dispatch starts or blocks on _command_lock until the
+    whole bundle is bound.
+
+    Drives command dispatch (_execute_command) and detection
+    (monitor_external_control) on real threads through their real code
+    paths; only _update_current_command_id is wrapped, purely to pin the
+    interleaving at the exact point being fixed.
+    """
+    node = make_node(client_methods=['return_home', 'stub'])
+    node.method_mapping = {'dock': 'return_home'}
+    node.grpc_connection_check = MagicMock(return_value=True)
+    node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(
+        command_id='own-dock-race-1'))
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'own-dock-race-1',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    reached_bind_point = threading.Event()
+    proceed_to_bind = threading.Event()
+    original_update = node._update_current_command_id
+
+    def racing_update(response: Optional[dict], method_name: str) -> None:
+        reached_bind_point.set()
+        proceed_to_bind.wait(timeout=2.0)
+        original_update(response, method_name)
+
+    node._update_current_command_id = racing_update
+
+    dispatch_thread = threading.Thread(
+        target=node._execute_command,
+        args=({
+            'id': 'cmd-dock-race',
+            'method': 'dock',
+            'args': {}
+        },),
+    )
+    dispatch_thread.start()
+    assert reached_bind_point.wait(timeout=2.0), 'dispatch never reached the id-bind point'
+
+    monitor_thread = threading.Thread(target=lambda: asyncio.run(node.monitor_external_control()))
+    monitor_thread.start()
+    # Grace period for the monitor to attempt _command_lock: enough for it to
+    # either finish (pre-fix: lock is free, the bug reproduces almost
+    # instantly) or still be blocked on it (post-fix: dispatch holds the
+    # lock through the whole bind).
+    time.sleep(0.1)
+    proceed_to_bind.set()
+
+    monitor_thread.join(timeout=2.0)
+    dispatch_thread.join(timeout=2.0)
+    assert not monitor_thread.is_alive()
+    assert not dispatch_thread.is_alive()
+
+    assert published_payloads(node) == []
+    assert node.external_control_active is False
+    assert node.task_id == 'cmd-dock-race'
+    assert node.current_command_id == 'own-dock-race-1'
+
+
 def test_recently_completed_dock_return_home_is_not_treated_as_external() -> None:
     """A dock that just completed is not mistaken for external control (concern (b)).
 

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -30,7 +30,10 @@ from pathlib import Path
 import sys
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import grpc
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
 
@@ -38,6 +41,16 @@ from connect_openrmf_by_zenoh import CommandCompletion  # noqa: E402
 from connect_openrmf_by_zenoh import KachakaApiClientByZenoh  # noqa: E402
 from connect_openrmf_by_zenoh import MapState  # noqa: E402
 from connect_openrmf_by_zenoh import Pose  # noqa: E402
+
+
+class FakeRpcError(grpc.RpcError):
+    """Minimal RpcError stand-in with the attributes the bridge reads."""
+
+    def code(self) -> grpc.StatusCode:
+        return grpc.StatusCode.DEADLINE_EXCEEDED
+
+    def details(self) -> str:
+        return 'Deadline Exceeded'
 
 
 def make_node(client_methods: list = []) -> KachakaApiClientByZenoh:
@@ -87,8 +100,28 @@ def make_node(client_methods: list = []) -> KachakaApiClientByZenoh:
     node.command_is_completed_pub = MagicMock()
     node.map_name_pub = MagicMock()
     node.pose_pub = MagicMock()
+    node.state_pub = MagicMock()
     node._publish_to_zenoh = MagicMock(return_value=True)
     node.kachaka_client = MagicMock(spec=client_methods)
+    # Issue #34 Step 2 state: near-distance short-circuit, split timeouts,
+    # command matching, external returnHome tracking, unified state seq.
+    node.noop_distance_tolerance = 0.15
+    node.noop_yaw_tolerance = 0.10
+    node.progress_distance_delta = 0.02
+    node.progress_yaw_delta = 0.02
+    node.command_match_distance_tolerance = 0.75
+    node.command_match_yaw_tolerance = 0.35
+    node.command_start_timeout = 15.0
+    node.motion_progress_timeout = 30.0
+    node.command_dispatched_at = None
+    node._motion_progress_pose = None
+    node._motion_progress_at = None
+    node.expected_kachaka_method = None
+    node.command_target_map_name = None
+    node.command_target_pose = None
+    node.external_control_active = False
+    node._external_command_id = None
+    node._state_seq = 0
     return node
 
 
@@ -97,6 +130,11 @@ def published_payloads(node: KachakaApiClientByZenoh) -> list:
     return [
         call.args[1] for call in node._publish_to_zenoh.call_args_list if call.args[0] is node.command_is_completed_pub
     ]
+
+
+def published_state_payloads(node: KachakaApiClientByZenoh) -> list:
+    """Return all payloads published on the unified robots/*/state publisher."""
+    return [call.args[1] for call in node._publish_to_zenoh.call_args_list if call.args[0] is node.state_pub]
 
 
 # ---------------------------------------------------------------------------
@@ -238,3 +276,392 @@ def test_stale_completion_does_not_reset_active_task() -> None:
     assert published_payloads(node) == [{'id': 'cmd-finished', 'is_completed': True, 'success': False}]
     assert node.task_id == 'cmd-active'
     assert node.last_progress_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Issue #34 Plan §7.1: near-distance short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_move_to_pose_short_circuits_within_noop_tolerance() -> None:
+    """A 14.9cm move within yaw tolerance succeeds once without calling Kachaka."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock()
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+
+    node._execute_command({
+        'id': 'cmd-noop',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 0.149,
+            'y': 0.0,
+            'yaw': 0.0,
+            'map_name': '8F'
+        },
+    })
+
+    node._execute_sync_method.assert_not_called()
+    assert published_payloads(node) == [{'id': 'cmd-noop', 'is_completed': True, 'success': True}]
+    assert node.task_id is None
+
+
+def test_move_to_pose_short_circuits_across_pi_seam() -> None:
+    """Yaw tolerance is checked after normalizing across the +/-pi wraparound."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock()
+    node.last_pose = Pose(0.0, 0.0, 3.10)
+
+    node._execute_command({
+        'id': 'cmd-noop-wrap',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 0.0,
+            'y': 0.0,
+            'yaw': -3.10,
+            'map_name': None
+        },
+    })
+
+    node._execute_sync_method.assert_not_called()
+    assert published_payloads(node) == [{'id': 'cmd-noop-wrap', 'is_completed': True, 'success': True}]
+
+
+def test_move_to_pose_dispatches_when_outside_noop_tolerance() -> None:
+    """A move beyond the noop tolerance is dispatched to Kachaka as normal."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-move'})
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+
+    node._execute_command({
+        'id': 'cmd-move',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 1.0,
+            'y': 0.0,
+            'yaw': 0.0,
+            'map_name': '8F'
+        },
+    })
+
+    node._execute_sync_method.assert_called_once()
+    assert node._execute_sync_method.call_args.kwargs['task_id'] == 'cmd-move'
+    assert node.expected_kachaka_method == 'move_to_pose'
+    assert node.command_target_map_name == '8F'
+    assert node.command_target_pose == Pose(1.0, 0.0, 0.0)
+    # The noop short-circuit must not have published a completion itself;
+    # _execute_sync_method (mocked here) owns publishing for the dispatch path.
+    assert published_payloads(node) == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #34 Plan §7.2: split command_start / motion_progress timeouts
+# ---------------------------------------------------------------------------
+
+
+def test_start_timeout_fires_before_running_observed() -> None:
+    """No RUNNING within command_start_timeout cancels and fails once with start_timeout."""
+    node = make_node(client_methods=['cancel_command'])
+    node.task_id = 'cmd-start'
+    node.is_async_command = True
+    node.saw_running = False
+    node.command_dispatched_at = time.monotonic() - 100.0
+    node.command_start_timeout = 0.05
+    node._get_command_state_response = MagicMock(return_value={'commandId': None, 'state': 'COMMAND_STATE_PENDING'})
+
+    asyncio.run(node.publish_result())
+
+    node.kachaka_client.cancel_command.assert_called_once()
+    assert published_payloads(node) == [{
+        'id': 'cmd-start',
+        'is_completed': True,
+        'success': False,
+        'reason': 'start_timeout',
+    }]
+    assert node.task_id is None
+
+
+def test_progress_timeout_fires_when_position_stalled_while_running() -> None:
+    """No position/yaw change within motion_progress_timeout fails once with progress_timeout."""
+    node = make_node(client_methods=['cancel_command'])
+    node.task_id = 'cmd-progress'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'grpc-p'
+    node.last_pose = Pose(1.0, 2.0, 0.0)
+    node._motion_progress_pose = Pose(1.0, 2.0, 0.0)
+    node._motion_progress_at = time.monotonic() - 100.0
+    node.motion_progress_timeout = 0.05
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'grpc-p',
+        'state': 'COMMAND_STATE_RUNNING'
+    })
+
+    asyncio.run(node.publish_result())
+
+    node.kachaka_client.cancel_command.assert_called_once()
+    assert published_payloads(node) == [{
+        'id': 'cmd-progress',
+        'is_completed': True,
+        'success': False,
+        'reason': 'progress_timeout',
+    }]
+
+
+def test_progress_timeout_does_not_fire_when_position_advances() -> None:
+    """A position change beyond the delta resets the motion_progress baseline."""
+    node = make_node()
+    node.task_id = 'cmd-moving'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'grpc-m'
+    node.last_pose = Pose(1.10, 2.0, 0.0)
+    node._motion_progress_pose = Pose(1.0, 2.0, 0.0)
+    node._motion_progress_at = time.monotonic() - 100.0
+    node.motion_progress_timeout = 1.0
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'grpc-m',
+        'state': 'COMMAND_STATE_RUNNING'
+    })
+
+    asyncio.run(node.publish_result())
+
+    # No timeout fired: only the in-progress (is_completed=False) update was published.
+    assert published_payloads(node) == [{'id': 'cmd-moving', 'is_completed': False}]
+    assert node.task_id == 'cmd-moving'
+    assert time.monotonic() - node._motion_progress_at < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Issue #34 Plan §7.3: RMF/Kachaka command matching
+# ---------------------------------------------------------------------------
+
+
+def test_command_type_mismatch_is_not_reported_as_success() -> None:
+    """A same-ID success whose command type differs from what was dispatched is rejected."""
+    node = make_node()
+    node.task_id = 'cmd-typed'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'grpc-typed'
+    node.expected_kachaka_method = 'move_to_pose'
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'grpc-typed',
+        'state': 'COMMAND_STATE_UNKNOWN'
+    })
+    node._get_last_command_result_response = MagicMock(return_value={
+        'commandId': 'grpc-typed',
+        'result': {
+            'success': True,
+            'errorCode': 0
+        },
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert published_payloads(node) == [{'id': 'cmd-typed', 'is_completed': True, 'success': False}]
+
+
+def test_command_floor_mismatch_at_completion_uses_map_mismatch_reason() -> None:
+    """A same-ID, same-type success on the wrong floor is rejected as map_mismatch."""
+    node = make_node()
+    node.task_id = 'cmd-floor'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'grpc-floor'
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_target_map_name = '8F'
+    node.map_state = MapState.initial().with_telemetry_map_name('9F')
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'grpc-floor',
+        'state': 'COMMAND_STATE_UNKNOWN'
+    })
+    node._get_last_command_result_response = MagicMock(return_value={
+        'commandId': 'grpc-floor',
+        'result': {
+            'success': True,
+            'errorCode': 0
+        },
+        'command': {
+            'moveToPoseCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-floor',
+        'is_completed': True,
+        'success': False,
+        'reason': 'map_mismatch',
+    }]
+
+
+def test_matching_command_type_and_floor_reports_success() -> None:
+    """A same-ID, same-type success on the correct floor is reported as success."""
+    node = make_node()
+    node.task_id = 'cmd-ok'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'grpc-ok'
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_target_map_name = '8F'
+    node.command_target_pose = Pose(1.0, 1.0, 0.0)
+    node.last_pose = Pose(1.0, 1.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'grpc-ok',
+        'state': 'COMMAND_STATE_UNKNOWN'
+    })
+    node._get_last_command_result_response = MagicMock(return_value={
+        'commandId': 'grpc-ok',
+        'result': {
+            'success': True,
+            'errorCode': 0
+        },
+        'command': {
+            'moveToPoseCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert published_payloads(node) == [{'id': 'cmd-ok', 'is_completed': True, 'success': True}]
+
+
+# ---------------------------------------------------------------------------
+# Issue #34 Plan §7.4: external returnHome
+# ---------------------------------------------------------------------------
+
+
+def test_external_return_home_preempts_active_rmf_task() -> None:
+    """A returnHome not issued by this bridge preempts the active RMF task once."""
+    node = make_node()
+    node.task_id = 'cmd-active-move'
+    node.last_command = {'id': 'cmd-active-move', 'method': 'move_to_pose', 'args': {}}
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-return-home-1',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-active-move',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node.task_id is None
+
+
+def test_own_dock_return_home_is_not_treated_as_external() -> None:
+    """RMF's own dock (return_home) command is never classified as external."""
+    node = make_node()
+    node.task_id = 'cmd-dock'
+    node.last_command = {'id': 'cmd-dock', 'method': 'dock', 'args': {}}
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'own-return-home-1',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == []
+    assert node.external_control_active is False
+    assert node.task_id == 'cmd-dock'
+
+
+def test_external_control_active_rejects_new_rmf_command_with_external_busy() -> None:
+    """An RMF command arriving while external control is active is rejected, not sent to Kachaka."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock()
+    node.external_control_active = True
+
+    node._execute_command({'id': 'cmd-during-external', 'method': 'move_to_pose', 'args': {'x': 5.0, 'y': 5.0}})
+
+    node._execute_sync_method.assert_not_called()
+    assert published_payloads(node) == [{
+        'id': 'cmd-during-external',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_busy',
+    }]
+    assert node.task_id is None
+
+
+def test_external_control_ends_when_return_home_no_longer_running() -> None:
+    """external_control_active clears once the external returnHome is no longer RUNNING."""
+    node = make_node()
+    node.external_control_active = True
+    node._external_command_id = 'ext-return-home-1'
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-return-home-1',
+        'state': 'COMMAND_STATE_SUCCEEDED'
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert node.external_control_active is False
+    assert node._external_command_id is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #34 Plan §5.1: unified robots/{robot_name}/state payload
+# ---------------------------------------------------------------------------
+
+
+def test_publish_state_discards_sample_when_map_changes_during_read() -> None:
+    """A floor change between the two floor reads (a racing switch_map) discards the sample."""
+    node = make_node()
+    node._fetch_robot_map_name = MagicMock(side_effect=['8F', '9F'])
+    node.kachaka_client = MagicMock()
+    node.kachaka_client.stub.GetRobotPose = MagicMock(return_value=SimpleNamespace(
+        pose=SimpleNamespace(x=1.0, y=2.0, theta=0.5)))
+
+    asyncio.run(node.publish_state())
+
+    assert published_state_payloads(node) == []
+    assert node._state_seq == 0
+
+
+def test_publish_state_publishes_when_floor_reads_agree() -> None:
+    """A consistent floor-before/floor-after read publishes a single seq'd state sample."""
+    node = make_node()
+    node._fetch_robot_map_name = MagicMock(side_effect=['8F', '8F'])
+    node.kachaka_client = MagicMock()
+    node.kachaka_client.stub.GetRobotPose = MagicMock(return_value=SimpleNamespace(
+        pose=SimpleNamespace(x=1.0, y=2.0, theta=0.5)))
+
+    asyncio.run(node.publish_state())
+
+    payloads = published_state_payloads(node)
+    assert len(payloads) == 1
+    assert payloads[0]['schema_version'] == 1
+    assert payloads[0]['seq'] == 1
+    assert payloads[0]['map_name'] == '8F'
+    assert payloads[0]['pose'] == [1.0, 2.0, 0.5]
+    assert payloads[0]['external_control_active'] is False
+
+
+def test_publish_state_discards_sample_on_grpc_error() -> None:
+    """A gRPC failure discards the sample instead of resending a stale pose under a new timestamp."""
+    node = make_node()
+    node.last_pose = Pose(9.0, 9.0, 9.0)
+    node._fetch_robot_map_name = MagicMock(side_effect=FakeRpcError())
+
+    asyncio.run(node.publish_state())
+
+    assert published_state_payloads(node) == []
+    assert node._state_seq == 0

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -96,6 +96,7 @@ def make_node(client_methods: list = []) -> KachakaApiClientByZenoh:
     node._client_lock = threading.RLock()
     node._dispatch_lock = threading.Lock()
     node.dispatching = False
+    node._pending_dispatch_snapshot_id = None
     node.last_progress_at = None
     node._ignored_result_count = 0
     node._first_grpc_failure_time = None
@@ -740,18 +741,23 @@ def test_final_pose_mismatch_is_not_reported_as_success() -> None:
 
 
 def test_wrong_type_running_command_is_not_bound_when_dispatch_lacked_command_id() -> None:
-    """A StartCommand response without commandId must not let a wrong-type RUNNING command bind later.
+    """publish_result() never binds current_command_id while it is unset, regardless of command type.
 
-    Reproduces Codex review ISS34-006's blocking finding: high-level
-    StartCommand often returns a bare Result with no commandId, so
-    current_command_id stays unbound after dispatch. Binding must still
-    require the observed command's type to match what was dispatched.
+    Codex re-review ISS34-037 blocking-1 removed publish_result()'s
+    type/target-based fallback bind entirely: ownership is captured solely
+    by StartCommand's response command_id at dispatch
+    (_execute_async_stub_dispatch), which now fails the task closed
+    (reason='missing_command_id') instead of ever leaving current_command_id
+    unbound while a task stays active. This state (current_command_id=None
+    with is_async_command=True) should therefore never arise in practice; if
+    it somehow does, an observed RUNNING command -- of any type -- must
+    still never be treated as progress or bound to this task.
     """
     node = make_node()
     node.task_id = 'cmd-nobind'
     node.is_async_command = True
     node.saw_running = False
-    node.current_command_id = None  # StartCommand response carried no commandId
+    node.current_command_id = None  # invariant violation: dispatch should have fail-closed instead
     node.expected_kachaka_method = 'move_to_pose'
     node.command_dispatched_at = time.monotonic()
     node._get_command_state_response = MagicMock(return_value={
@@ -769,8 +775,16 @@ def test_wrong_type_running_command_is_not_bound_when_dispatch_lacked_command_id
     assert published_payloads(node) == []
 
 
-def test_correct_type_running_command_binds_when_dispatch_lacked_command_id() -> None:
-    """A matching-type RUNNING command still binds normally after a commandId-less dispatch."""
+def test_correct_type_running_command_does_not_bind_when_dispatch_lacked_command_id() -> None:
+    """A matching-type RUNNING command does not bind current_command_id via publish_result() either.
+
+    Rewritten for the fail-closed design (Issue #34 Plan §7.3/§7.4, Codex
+    re-review ISS34-037 blocking-1): the previous fallback used to bind on a
+    type match alone once running_state_wait expired. That path is removed;
+    _execute_async_stub_dispatch is now the only place current_command_id is
+    ever set, and it fails the dispatch closed whenever StartCommand's
+    response carries no command_id.
+    """
     node = make_node()
     node.task_id = 'cmd-bind-ok'
     node.is_async_command = True
@@ -788,21 +802,17 @@ def test_correct_type_running_command_binds_when_dispatch_lacked_command_id() ->
 
     asyncio.run(node.publish_result())
 
-    assert node.current_command_id == 'grpc-bind-ok'
-    assert node.saw_running is True
-    assert published_payloads(node) == [{'id': 'cmd-bind-ok', 'is_completed': False}]
+    assert node.current_command_id is None
+    assert node.saw_running is False
+    assert published_payloads(node) == []
 
 
 def test_same_type_running_command_with_mismatched_target_is_not_bound() -> None:
     """A same-type RUNNING move_to_pose toward a different target is not bound to our task.
 
-    Reproduces Codex re-review ISS34-010 blocking-2: the previous bind
-    condition checked only that the observed command's type matched
-    (moveToPoseCommand), so a same-type command started by someone else (or
-    a stale one) toward a different destination would still bind and its
-    later success would be reported to RMF as our task's success. Binding
-    must also confirm the observed command's own target matches what we
-    dispatched (Issue #34 Plan §7.3).
+    Type/target confirmation is no longer part of the ownership decision at
+    all (Codex re-review ISS34-037 blocking-1 removed it): current_command_id
+    stays unbound regardless of how closely the observed command matches.
     """
     node = make_node()
     node.task_id = 'cmd-ext-move'
@@ -832,8 +842,18 @@ def test_same_type_running_command_with_mismatched_target_is_not_bound() -> None
     assert published_payloads(node) == []
 
 
-def test_same_type_running_command_with_matching_target_still_binds() -> None:
-    """A same-type RUNNING move_to_pose whose own target matches ours still binds normally."""
+def test_same_type_running_command_with_matching_target_does_not_bind_without_dispatch_time_id() -> None:
+    """Even a perfectly type/target-matching RUNNING command is never bound by publish_result().
+
+    Direct regression test for Codex re-review ISS34-037 blocking-1: the
+    previous design (test name ended in "_still_binds") treated a matching
+    command type and target as sufficient ownership proof and bound
+    current_command_id here. That was exactly the gap a same-type/target
+    external command racing an ID-less dispatch could exploit to have its
+    own success reported as this task's success. Ownership is now captured
+    exclusively at dispatch time (StartCommand's response command_id); this
+    match must not bind anything.
+    """
     node = make_node()
     node.task_id = 'cmd-own-move'
     node.is_async_command = True
@@ -857,9 +877,9 @@ def test_same_type_running_command_with_matching_target_still_binds() -> None:
 
     asyncio.run(node.publish_result())
 
-    assert node.current_command_id == 'own-move-1'
-    assert node.saw_running is True
-    assert published_payloads(node) == [{'id': 'cmd-own-move', 'is_completed': False}]
+    assert node.current_command_id is None
+    assert node.saw_running is False
+    assert published_payloads(node) == []
 
 
 # ---------------------------------------------------------------------------
@@ -1157,15 +1177,18 @@ def test_external_return_home_id_conflict_with_rmf_dock_is_not_reported_as_succe
     assert node.last_command_result == CommandCompletion('cmd-dock', True, False, -8, 'external_preempted')
 
 
-def test_external_return_home_when_own_dispatch_never_bound_id_is_detected_as_external() -> None:
-    """A returnHome is treated as external when our own dock dispatch never bound a command_id.
+def test_missing_command_id_on_dispatch_fails_closed_instead_of_leaving_ownership_ambiguous() -> None:
+    """A dock dispatch whose StartCommand response carries no command_id fails closed immediately.
 
-    Defensive coverage for Issue #34 Plan §7.4 blocking-3: even if
-    StartCommandResponse carried no command_id (should not normally happen
-    once a stub-direct dispatch reports success), an unbound own
-    command_id must never be treated as plausibly ours -- unlike the
-    previous running_state_wait-window fallback, which assumed an unbound
-    id was ours for the whole window.
+    Rewritten for Codex re-review ISS34-037 blocking-1: the previous design
+    (Issue #34 Plan §7.4 blocking-3) left current_command_id unbound and
+    relied on downstream detection (monitor_external_control/publish_result)
+    to never mistake a later RUNNING command for this task's own via a
+    type/target match. That fallback has been removed entirely --
+    _execute_async_stub_dispatch now fails the task closed
+    (reason='missing_command_id') the moment StartCommand's success response
+    carries no command_id, so ownership is never left ambiguous to begin
+    with.
     """
     node = make_node(client_methods=['return_home', 'stub'])
     node.method_mapping = {'dock': 'return_home'}
@@ -1173,8 +1196,19 @@ def test_external_return_home_when_own_dispatch_never_bound_id_is_detected_as_ex
     node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(command_id=None))
 
     node._execute_command({'id': 'cmd-dock-3', 'method': 'dock', 'args': {}})
-    assert node.current_command_id is None
 
+    assert node.current_command_id is None
+    assert node.task_id is None
+    assert published_payloads(node) == [{
+        'id': 'cmd-dock-3',
+        'is_completed': True,
+        'success': False,
+        'reason': 'missing_command_id',
+    }]
+
+    # A RUNNING command observed afterward is correctly treated as external
+    # while idle (no RMF task left to preempt) -- cmd-dock-3 was already
+    # failed closed and cannot be attributed to it.
     node._get_command_state_response = MagicMock(return_value={
         'commandId': 'ext-return-home-3',
         'state': 'COMMAND_STATE_RUNNING',
@@ -1189,7 +1223,7 @@ def test_external_return_home_when_own_dispatch_never_bound_id_is_detected_as_ex
         'id': 'cmd-dock-3',
         'is_completed': True,
         'success': False,
-        'reason': 'external_preempted',
+        'reason': 'missing_command_id',
     }]
     assert node.external_control_active is True
 
@@ -1271,18 +1305,20 @@ def test_start_command_success_and_id_bind_are_atomic_under_concurrent_monitor()
     assert node.current_command_id == 'own-dock-race-1'
 
 
-def test_dispatch_pending_defers_external_detection_then_catches_it_after_dispatch_settles() -> None:
-    """monitor_external_control() defers while dispatching, but still catches the external command after.
+def test_dispatch_pending_snapshot_reconciled_as_external_even_after_it_ends() -> None:
+    """A RUNNING command observed only during the dispatch window is still caught by reconciliation.
 
-    Issue #34 Plan §5 dispatch-pending hold: while dispatching=True our own
-    command_id is not yet bound (_execute_async_stub_dispatch's gRPC call
-    runs outside _command_lock), so a concurrent monitor_external_control()
-    poll must not judge ownership yet -- it could misclassify our own
-    not-yet-bound dispatch as external. But deferring must not mean
-    permanently missing a genuinely external command: once the dispatch
-    settles and current_command_id is bound, the same external command_id
-    observed on the next poll must still be recognized and preempt/mark
-    busy immediately, not be silently dropped by having deferred once.
+    Issue #34 Plan §5 "remember snapshot.commandId for reconciliation": while
+    dispatching=True our own command_id is not yet bound
+    (_execute_async_stub_dispatch's gRPC call runs outside _command_lock), so
+    a concurrent monitor_external_control() poll must not judge ownership
+    yet -- it could misclassify our own not-yet-bound dispatch as external.
+    Deferring must not mean permanently missing a genuinely external
+    command, though: the external command here has already ended (per the
+    second GetCommandState response, taken after the dispatch settles), so
+    only the remembered snapshot -- not a fresh live poll -- can still catch
+    it (Codex re-review ISS34-037 non-blocking finding: the previous design
+    discarded the dispatch-time snapshot outright).
 
     Drives command dispatch (_execute_command) and detection
     (monitor_external_control) on real threads through their real code
@@ -1303,8 +1339,11 @@ def test_dispatch_pending_defers_external_detection_then_catches_it_after_dispat
         return stub_start_command_response(command_id='own-dock-race-2')
 
     node.kachaka_client.stub.StartCommand = MagicMock(side_effect=racing_start_command)
-    node._get_command_state_response = MagicMock(
-        return_value={
+    # The external command is RUNNING only on the first (dispatch-time) poll;
+    # every later live poll finds the robot idle, so detection can only come
+    # from the remembered snapshot, never a fresh GetCommandState call.
+    node._get_command_state_response = MagicMock(side_effect=[
+        {
             'commandId': 'ext-during-dispatch',
             'state': 'COMMAND_STATE_RUNNING',
             'command': {
@@ -1312,7 +1351,12 @@ def test_dispatch_pending_defers_external_detection_then_catches_it_after_dispat
                     'targetLocationId': 'home'
                 }
             },
-        })
+        },
+        {
+            'commandId': None,
+            'state': 'COMMAND_STATE_IDLE'
+        },
+    ])
 
     dispatch_thread = threading.Thread(
         target=node._execute_command,
@@ -1329,15 +1373,16 @@ def test_dispatch_pending_defers_external_detection_then_catches_it_after_dispat
     asyncio.run(node.monitor_external_control())
     assert published_payloads(node) == []
     assert node.external_control_active is False
+    assert node._pending_dispatch_snapshot_id == 'ext-during-dispatch'
 
     proceed_with_grpc.set()
     dispatch_thread.join(timeout=2.0)
     assert not dispatch_thread.is_alive()
-    assert node.current_command_id == 'own-dock-race-2'
     assert node.dispatching is False
 
-    asyncio.run(node.monitor_external_control())
-
+    # Reconciliation ran synchronously inside _execute_command's finally
+    # block (not a fresh poll) and caught the now-ended external command,
+    # preempting the dispatch that raced it.
     assert published_payloads(node) == [{
         'id': 'cmd-dock-race-2',
         'is_completed': True,
@@ -1347,6 +1392,107 @@ def test_dispatch_pending_defers_external_detection_then_catches_it_after_dispat
     assert node.external_control_active is True
     assert node._external_command_id == 'ext-during-dispatch'
     assert node.task_id is None
+    assert node.current_command_id is None
+    assert node._pending_dispatch_snapshot_id is None
+
+    # A live poll now correctly reports idle, confirming the detection above
+    # came from the remembered snapshot, not this (or any) fresh poll.
+    asyncio.run(node.monitor_external_control())
+    assert node.external_control_active is False
+
+
+def test_missing_command_id_race_never_lets_publish_result_bind_external_success() -> None:
+    """Blocking-1 regression (Codex ISS34-037): a same-target external command can never poison a failed dispatch.
+
+    Reproduces the exact interleaving Codex's read-only simulation found,
+    with real threads: (1) monitor_external_control() runs first and finds
+    nothing external (idle robot) -- modeling "monitor completed" before the
+    race; (2) a separate thread dispatches move_to_pose via _execute_command
+    (command dispatch runs on its own thread in production, not the main
+    loop) -- the mocked stub.StartCommand reports success but returns an
+    empty command_id, the anomaly this fix must fail closed on; (3) once the
+    dispatch thread has published its failure completion, a same-target
+    external moveToPoseCommand appears RUNNING; (4) publish_result() must
+    never bind current_command_id to it or report its eventual success as
+    this (already-failed) task's own.
+
+    Before this fix, step (2) would have left current_command_id unbound
+    (only a warning logged) and the task still active; publish_result()'s
+    type/target fallback bind (removed in Step 2/3 of this change) would
+    then have bound the external command's id in step (4), and a later
+    success for it would have been reported as cmd-race-missing-id's own
+    success. Fail-closed dispatch (Step 3) means the task is already gone by
+    step (4), so there is nothing left to poison in the first place.
+    """
+    node = make_node(client_methods=['move_to_pose', 'stub'])
+    node.method_mapping = {}
+    node.grpc_connection_check = MagicMock(return_value=True)
+    node.map_state = MapState.initial().with_telemetry_map_name('L1')
+    node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(command_id=None))
+
+    # (1) monitor_external_control() runs first, on an idle robot.
+    node._get_command_state_response = MagicMock(return_value={'commandId': None, 'state': 'COMMAND_STATE_IDLE'})
+    asyncio.run(node.monitor_external_control())
+    assert node.external_control_active is False
+
+    # (2) a separate thread dispatches move_to_pose; StartCommand succeeds
+    # but returns no command_id.
+    dispatch_thread = threading.Thread(
+        target=node._execute_command,
+        args=({
+            'id': 'cmd-race-missing-id',
+            'method': 'move_to_pose',
+            'args': {
+                'x': 1.0,
+                'y': 1.0,
+                'yaw': 0.0,
+                'map_name': 'L1'
+            },
+        },),
+    )
+    dispatch_thread.start()
+    dispatch_thread.join(timeout=2.0)
+    assert not dispatch_thread.is_alive()
+
+    failure_payload = {
+        'id': 'cmd-race-missing-id',
+        'is_completed': True,
+        'success': False,
+        'reason': 'missing_command_id',
+    }
+    # Fail-closed: the task was completed as a failure, never left dangling
+    # for a later poll to bind.
+    assert published_payloads(node) == [failure_payload]
+    assert node.task_id is None
+    assert node.current_command_id is None
+
+    # (3) a same-target external moveToPoseCommand now appears RUNNING.
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'external-move-race-1',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 1.0,
+                    'y': 1.0,
+                    'yaw': 0.0
+                }
+            },
+        })
+
+    # (4) publish_result() has no active task to poll for -- it only
+    # re-publishes the already-failed completion for Pub/Sub reliability --
+    # so it must never bind current_command_id or report a new success.
+    asyncio.run(node.publish_result())
+    assert node.current_command_id is None
+    assert node.task_id is None
+    assert all(payload == failure_payload for payload in published_payloads(node))
+
+    # monitor_external_control() correctly reports the same command as
+    # external (idle, not attributed to cmd-race-missing-id) once polled.
+    asyncio.run(node.monitor_external_control())
+    assert node.external_control_active is True
+    assert node._external_command_id == 'external-move-race-1'
 
 
 def test_recently_completed_dock_return_home_is_not_treated_as_external() -> None:

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -740,6 +740,53 @@ def test_final_pose_mismatch_is_not_reported_as_success() -> None:
     assert published_payloads(node) == [{'id': 'cmd-pose', 'is_completed': True, 'success': False}]
 
 
+def test_state_pending_with_missing_id_still_reports_success_via_last_result() -> None:
+    """A normal completion observed as PENDING/missing state commandId must still reach GetLastCommandResult.
+
+    Codex re-review ISS34-042: publish_result() required an exact state
+    commandId match before even checking whether the state was RUNNING,
+    so it returned early on every non-RUNNING poll -- including the normal
+    completion transition. Real hardware (ISS34-034 log analysis,
+    worker1_details_iss34-034.md rows #13-#14) shows Kachaka transitioning
+    to COMMAND_STATE_PENDING with an empty state commandId right after a
+    command finishes, while GetLastCommandResult still reports the
+    completed command's own commandId with success=True. Unlike
+    test_matching_command_type_and_floor_reports_success (which gives the
+    state poll a matching own id and therefore cannot detect this gap),
+    this test leaves the state commandId empty on purpose. The state-side
+    exact-match check must only gate RUNNING progress, not block reaching
+    GetLastCommandResult for completion ownership.
+    """
+    node = make_node()
+    node.task_id = 'cmd-normal'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'own-id-3'
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_target_map_name = '8F'
+    node.command_target_pose = Pose(1.0, 1.0, 0.0)
+    node.last_pose = Pose(1.0, 1.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': None,
+        'state': 'COMMAND_STATE_PENDING',
+    })
+    node._get_last_command_result_response = MagicMock(return_value={
+        'commandId': 'own-id-3',
+        'result': {
+            'success': True,
+            'errorCode': 0
+        },
+        'command': {
+            'moveToPoseCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert published_payloads(node) == [{'id': 'cmd-normal', 'is_completed': True, 'success': True}]
+
+
 def test_bound_command_missing_state_command_id_is_not_treated_as_progress() -> None:
     """A RUNNING GetCommandState response missing commandId must not be accepted as our bound command.
 

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -19,8 +19,14 @@ Covers the stuck-robot bugs fixed in the race-condition audit:
 - every failure path of _execute_command publishes a failure completion
 - a re-issued in-flight command adopts the new ID without re-execution
 - the completion watchdog force-completes a silent task (error_code=-5)
-- a wrong command_id binding is undone after persistent mismatches
+- a persistent command_id mismatch never undoes the own binding
 - completion publishing is idempotent and never wipes a newer task's state
+
+Also covers the Issue #34 Plan §5 generalization of external-command
+detection (ISS34-036): any non-own RUNNING command (not only
+returnHomeCommand) preempts an active RMF task or marks busy while idle,
+ownership is decided purely by bounded command_id equality, and an
+external id can never be rebound onto an own task's completion.
 """
 # ruff: noqa: SLF001
 
@@ -125,8 +131,8 @@ def make_node(client_methods: list = []) -> KachakaApiClientByZenoh:
     node.external_control_active = False
     node._external_command_id = None
     node.own_return_home_retention = 5.0
-    node._recently_own_return_home_id = None
-    node._recently_own_return_home_until = None
+    node._recently_completed_own_command_id = None
+    node._recently_completed_own_command_until = None
     node._state_seq = 0
     return node
 
@@ -253,23 +259,28 @@ def test_watchdog_does_not_fire_while_progressing() -> None:
 
 
 # ---------------------------------------------------------------------------
-# A-3: wrong command_id binding is undone after persistent mismatches
+# A-3: a persistent command_id mismatch never undoes the own binding
 # ---------------------------------------------------------------------------
 
 
-def test_persistent_mismatch_unbinds_command_id() -> None:
-    """MAX_IGNORED_MISMATCHES consecutive mismatches undo the binding."""
+def test_persistent_mismatch_never_unbinds_command_id() -> None:
+    """Repeated mismatches, even past MAX_IGNORED_MISMATCHES, never clear current_command_id.
+
+    Reproduces the ISS34-035 gap analysis finding: unbinding on persistent
+    mismatch used to let a same-type/target external command rebind onto
+    this task once _ignored_result_count reached MAX_IGNORED_MISMATCHES.
+    Own binding is decided once, synchronously, at dispatch (StartCommand's
+    response) and must never be undone by later mismatched observations --
+    a genuinely external command is instead handled by
+    monitor_external_control(), which preempts the task outright.
+    """
     node = make_node()
     node.task_id = 'cmd-3'
     node.current_command_id = 'grpc-old'
 
-    for _ in range(KachakaApiClientByZenoh.MAX_IGNORED_MISMATCHES - 1):
+    for _ in range(KachakaApiClientByZenoh.MAX_IGNORED_MISMATCHES * 2):
         node._note_ignored_mismatch('command state', 'grpc-new')
         assert node.current_command_id == 'grpc-old'
-
-    node._note_ignored_mismatch('command state', 'grpc-new')
-    assert node.current_command_id is None
-    assert node._ignored_result_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -928,6 +939,103 @@ def test_external_return_home_preempts_active_rmf_task() -> None:
     assert node.task_id is None
 
 
+def test_external_move_to_location_home_preempts_active_rmf_task() -> None:
+    """A moveToLocationCommand(targetLocationId='home') not issued by this bridge preempts immediately.
+
+    Reproduces the ISS34-034 hardware finding: the real Kachaka app's
+    Return Home button issues moveToLocationCommand, not returnHomeCommand,
+    so a returnHomeCommand-only check never observes it. Detection must
+    treat any non-own RUNNING command as external regardless of type
+    (Issue #34 Plan §5), so this is caught on the very first observation.
+    """
+    node = make_node()
+    node.task_id = 'cmd-active-move'
+    node.last_command = {'id': 'cmd-active-move', 'method': 'move_to_pose', 'args': {}}
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'ext-move-to-location-home',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToLocationCommand': {
+                    'targetLocationId': 'home'
+                }
+            },
+        })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-active-move',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node.task_id is None
+
+
+def test_external_move_to_location_non_home_target_preempts_active_rmf_task() -> None:
+    """A moveToLocationCommand toward any targetLocationId (not just 'home') preempts immediately.
+
+    Detection must never depend on the target value: any non-own RUNNING
+    moveToLocationCommand is external regardless of destination.
+    """
+    node = make_node()
+    node.task_id = 'cmd-active-move-2'
+    node.last_command = {'id': 'cmd-active-move-2', 'method': 'move_to_pose', 'args': {}}
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'ext-move-to-location-other',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToLocationCommand': {
+                    'targetLocationId': 'kitchen'
+                }
+            },
+        })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-active-move-2',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node.task_id is None
+
+
+def test_external_unrecognized_command_type_defaults_to_busy() -> None:
+    """A RUNNING command of a type not in KNOWN_MOVEMENT_COMMAND_FIELDS still defaults to busy.
+
+    Detection never gates on the known-type set -- it exists only to
+    control a diagnostic log message. Any non-own RUNNING command occupies
+    the movement/command-processor slot (Issue #34 Plan §5).
+    """
+    node = make_node()
+    node.task_id = 'cmd-active-move-3'
+    node.last_command = {'id': 'cmd-active-move-3', 'method': 'move_to_pose', 'args': {}}
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-unknown-type',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'someFutureCommand': {}
+        },
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-active-move-3',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node.task_id is None
+
+
 def test_own_dock_return_home_is_not_treated_as_external() -> None:
     """RMF's own dispatched dock (return_home) is never classified as external.
 
@@ -960,6 +1068,43 @@ def test_own_dock_return_home_is_not_treated_as_external() -> None:
     assert published_payloads(node) == []
     assert node.external_control_active is False
     assert node.task_id == 'cmd-dock'
+
+
+def test_own_move_to_pose_is_not_treated_as_external() -> None:
+    """RMF's own dispatched move_to_pose is never classified as external.
+
+    Ownership is decided purely by command_id equality, the same as dock
+    (Issue #34 Plan §5); this also demonstrates that the upstream requester
+    (e.g. an RMF Web API task like kachaka-rmf-control's charge_station
+    request) is irrelevant to the ownership judgement -- only whether the
+    bridge itself dispatched and bound the command_id matters.
+    """
+    node = make_node(client_methods=['move_to_pose', 'stub'])
+    node.grpc_connection_check = MagicMock(return_value=True)
+    node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(
+        command_id='own-move-to-pose-1'))
+
+    node._execute_command({'id': 'cmd-move', 'method': 'move_to_pose', 'args': {'x': 1.0, 'y': 2.0, 'yaw': 0.0}})
+    assert node.current_command_id == 'own-move-to-pose-1'
+
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'own-move-to-pose-1',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 1.0,
+                    'y': 2.0,
+                    'yaw': 0.0
+                }
+            },
+        })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == []
+    assert node.external_control_active is False
+    assert node.task_id == 'cmd-move'
 
 
 def test_external_return_home_id_conflict_with_rmf_dock_is_not_reported_as_success() -> None:
@@ -1126,6 +1271,84 @@ def test_start_command_success_and_id_bind_are_atomic_under_concurrent_monitor()
     assert node.current_command_id == 'own-dock-race-1'
 
 
+def test_dispatch_pending_defers_external_detection_then_catches_it_after_dispatch_settles() -> None:
+    """monitor_external_control() defers while dispatching, but still catches the external command after.
+
+    Issue #34 Plan §5 dispatch-pending hold: while dispatching=True our own
+    command_id is not yet bound (_execute_async_stub_dispatch's gRPC call
+    runs outside _command_lock), so a concurrent monitor_external_control()
+    poll must not judge ownership yet -- it could misclassify our own
+    not-yet-bound dispatch as external. But deferring must not mean
+    permanently missing a genuinely external command: once the dispatch
+    settles and current_command_id is bound, the same external command_id
+    observed on the next poll must still be recognized and preempt/mark
+    busy immediately, not be silently dropped by having deferred once.
+
+    Drives command dispatch (_execute_command) and detection
+    (monitor_external_control) on real threads through their real code
+    paths: the mocked stub.StartCommand pauses on an Event outside
+    _command_lock (mirroring the real gRPC call), which is the exact window
+    where dispatching=True but current_command_id is still unbound.
+    """
+    node = make_node(client_methods=['return_home', 'stub'])
+    node.method_mapping = {'dock': 'return_home'}
+    node.grpc_connection_check = MagicMock(return_value=True)
+
+    reached_grpc_call = threading.Event()
+    proceed_with_grpc = threading.Event()
+
+    def racing_start_command(_request: object) -> object:
+        reached_grpc_call.set()
+        proceed_with_grpc.wait(timeout=2.0)
+        return stub_start_command_response(command_id='own-dock-race-2')
+
+    node.kachaka_client.stub.StartCommand = MagicMock(side_effect=racing_start_command)
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'ext-during-dispatch',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToLocationCommand': {
+                    'targetLocationId': 'home'
+                }
+            },
+        })
+
+    dispatch_thread = threading.Thread(
+        target=node._execute_command,
+        args=({
+            'id': 'cmd-dock-race-2',
+            'method': 'dock',
+            'args': {}
+        },),
+    )
+    dispatch_thread.start()
+    assert reached_grpc_call.wait(timeout=2.0), 'dispatch never reached the gRPC call'
+    assert node.dispatching is True
+
+    asyncio.run(node.monitor_external_control())
+    assert published_payloads(node) == []
+    assert node.external_control_active is False
+
+    proceed_with_grpc.set()
+    dispatch_thread.join(timeout=2.0)
+    assert not dispatch_thread.is_alive()
+    assert node.current_command_id == 'own-dock-race-2'
+    assert node.dispatching is False
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-dock-race-2',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node._external_command_id == 'ext-during-dispatch'
+    assert node.task_id is None
+
+
 def test_recently_completed_dock_return_home_is_not_treated_as_external() -> None:
     """A dock that just completed is not mistaken for external control (concern (b)).
 
@@ -1136,8 +1359,8 @@ def test_recently_completed_dock_return_home_is_not_treated_as_external() -> Non
     node = make_node(client_methods=['move_to_pose'])
     node.task_id = None  # dock already completed; task_id was reset
     node.last_command = {'id': 'cmd-dock-done', 'method': 'dock', 'args': {}}
-    node._recently_own_return_home_id = 'own-return-home-2'
-    node._recently_own_return_home_until = time.monotonic() + node.own_return_home_retention
+    node._recently_completed_own_command_id = 'own-return-home-2'
+    node._recently_completed_own_command_until = time.monotonic() + node.own_return_home_retention
     node._get_command_state_response = MagicMock(return_value={
         'commandId': 'own-return-home-2',
         'state': 'COMMAND_STATE_RUNNING',
@@ -1158,6 +1381,44 @@ def test_recently_completed_dock_return_home_is_not_treated_as_external() -> Non
     node._execute_async_stub_dispatch.assert_called_once()
 
 
+def test_recently_completed_move_to_pose_is_not_treated_as_external() -> None:
+    """A move_to_pose that just completed/was superseded is not mistaken for external control.
+
+    Generalizes concern (b) beyond dock/return_home (Issue #34 Plan §5): a
+    cancel/supersession or ordinary completion of a move_to_pose can also
+    leave Kachaka briefly reporting the old command_id as RUNNING, and that
+    must not be misclassified as an external command either.
+    """
+    node = make_node(client_methods=['move_to_pose'])
+    node.task_id = None  # move_to_pose already completed/superseded; task_id was reset
+    node.last_command = {'id': 'cmd-move-done', 'method': 'move_to_pose', 'args': {'x': 1.0, 'y': 1.0}}
+    node._recently_completed_own_command_id = 'own-move-2'
+    node._recently_completed_own_command_until = time.monotonic() + node.own_return_home_retention
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'own-move-2',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 1.0,
+                    'y': 1.0,
+                    'yaw': 0.0
+                }
+            },
+        })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert node.external_control_active is False
+    assert published_payloads(node) == []
+
+    # A following RMF move must not be rejected with external_busy.
+    node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-next-move-2'})
+    node._execute_command({'id': 'cmd-next-move-2', 'method': 'move_to_pose', 'args': {'x': 5.0, 'y': 5.0}})
+    assert published_payloads(node) == []
+    node._execute_async_stub_dispatch.assert_called_once()
+
+
 def test_own_return_home_retention_recorded_on_dock_completion() -> None:
     """A successful dock completion records its command_id for the retention grace period."""
     node = make_node()
@@ -1167,9 +1428,29 @@ def test_own_return_home_retention_recorded_on_dock_completion() -> None:
 
     assert node._publish_command_completion(success=True, error_code=0) is True
 
-    assert node._recently_own_return_home_id == 'own-return-home-3'
-    assert node._recently_own_return_home_until is not None
-    assert node._recently_own_return_home_until > time.monotonic()
+    assert node._recently_completed_own_command_id == 'own-return-home-3'
+    assert node._recently_completed_own_command_until is not None
+    assert node._recently_completed_own_command_until > time.monotonic()
+    assert node.task_id is None
+
+
+def test_own_command_retention_recorded_on_move_to_pose_completion() -> None:
+    """A successful move_to_pose completion also records its command_id for the retention grace period.
+
+    Generalizes retention beyond the dock-only gate that used to guard
+    _record_own_return_home_retention (Issue #34 Plan §5): any own async
+    command with a bound command_id gets the same grace period.
+    """
+    node = make_node()
+    node.task_id = 'cmd-move-3'
+    node.last_command = {'id': 'cmd-move-3', 'method': 'move_to_pose', 'args': {'x': 1.0, 'y': 1.0}}
+    node.current_command_id = 'own-move-3'
+
+    assert node._publish_command_completion(success=True, error_code=0) is True
+
+    assert node._recently_completed_own_command_id == 'own-move-3'
+    assert node._recently_completed_own_command_until is not None
+    assert node._recently_completed_own_command_until > time.monotonic()
     assert node.task_id is None
 
 
@@ -1211,9 +1492,9 @@ def test_own_return_home_retention_recorded_via_publish_result_completion_path()
 
     assert published_payloads(node) == [{'id': 'cmd-dock-normal', 'is_completed': True, 'success': True}]
     assert node.task_id is None
-    assert node._recently_own_return_home_id == 'own-return-home-normal'
-    assert node._recently_own_return_home_until is not None
-    assert node._recently_own_return_home_until > time.monotonic()
+    assert node._recently_completed_own_command_id == 'own-return-home-normal'
+    assert node._recently_completed_own_command_until is not None
+    assert node._recently_completed_own_command_until > time.monotonic()
 
     # A lingering RUNNING return_home right after must still be recognized as ours.
     node._get_command_state_response = MagicMock(return_value={
@@ -1259,6 +1540,179 @@ def test_external_control_ends_when_return_home_no_longer_running() -> None:
 
     assert node.external_control_active is False
     assert node._external_command_id is None
+
+
+def test_external_command_while_idle_sets_busy_and_clears_when_gone() -> None:
+    """An external command observed while RMF is idle sets busy, and clears once it disappears.
+
+    No active RMF task exists (task_id is None) when the external command
+    starts, so there is nothing to preempt -- only external_control_active
+    needs to flip to True. Once the command is no longer RUNNING,
+    external_control_active clears and a fresh state publish follows on the
+    next main-loop iteration's publish_state() call (Issue #34 Plan §5).
+    """
+    node = make_node()
+    node.task_id = None
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'ext-idle-1',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToLocationCommand': {
+                    'targetLocationId': 'home'
+                }
+            },
+        })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == []  # nothing to preempt
+    assert node.external_control_active is True
+    assert node._external_command_id == 'ext-idle-1'
+
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-idle-1',
+        'state': 'COMMAND_STATE_SUCCEEDED'
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert node.external_control_active is False
+    assert node._external_command_id is None
+
+
+def test_external_control_active_persists_across_external_command_id_switch() -> None:
+    """Busy must not be cleared just because the external command_id changes to another non-own id.
+
+    Reproduces Issue #34 Plan §5's continuity requirement: e.g. the Kachaka
+    app's Return Home completes and the user immediately issues another
+    external move -- external_control_active must stay True the whole time,
+    only clearing once no non-own RUNNING command remains at all.
+    """
+    node = make_node()
+    node.task_id = None
+    node.external_control_active = True
+    node._external_command_id = 'ext-first'
+
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'ext-second',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 1.0,
+                    'y': 1.0,
+                    'yaw': 0.0
+                }
+            },
+        })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert node.external_control_active is True
+    assert node._external_command_id == 'ext-second'
+    assert published_payloads(node) == []
+
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-second',
+        'state': 'COMMAND_STATE_SUCCEEDED'
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert node.external_control_active is False
+    assert node._external_command_id is None
+
+
+def test_external_move_to_pose_with_matching_target_preempts_and_is_never_rebound() -> None:
+    """An external moveToPoseCommand toward the same target as ours preempts, never rebinds its id.
+
+    Reproduces the ISS34-035 gap analysis finding: an external move whose
+    target happens to be within RMF's own command_match tolerance used to
+    be able to rebind onto the active task after repeated mismatches
+    (_note_ignored_mismatch's old unbind-then-rebind path). Same-target
+    coincidence must not matter -- a non-own id is always external.
+    """
+    node = make_node()
+    node.task_id = 'cmd-own-move'
+    node.last_command = {'id': 'cmd-own-move', 'method': 'move_to_pose', 'args': {'x': 1.0, 'y': 1.0}}
+    node.current_command_id = 'own-move-active'
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_target_pose = Pose(1.0, 1.0, 0.0)
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'ext-move-same-target',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 1.0,
+                    'y': 1.0,
+                    'yaw': 0.0
+                }
+            },
+        })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-own-move',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node.task_id is None
+    assert node.current_command_id != 'ext-move-same-target'
+
+
+def test_external_move_to_pose_never_rebinds_even_after_repeated_mismatches() -> None:
+    """Repeated command-state mismatches against an own binding never let an external id take over.
+
+    End-to-end version of the ISS34-035 gap: even if publish_result() polls
+    the mismatching external id MAX_IGNORED_MISMATCHES times first (as could
+    happen before monitor_external_control() catches it), current_command_id
+    must remain the original own id throughout, and once
+    monitor_external_control() runs it must preempt rather than let the
+    external id quietly take over.
+    """
+    node = make_node()
+    node.task_id = 'cmd-own-move-2'
+    node.last_command = {'id': 'cmd-own-move-2', 'method': 'move_to_pose', 'args': {'x': 1.0, 'y': 1.0}}
+    node.current_command_id = 'own-move-active-2'
+    node.is_async_command = True
+    node.saw_running = True
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_target_pose = Pose(1.0, 1.0, 0.0)
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'ext-move-persistent',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 1.0,
+                    'y': 1.0,
+                    'yaw': 0.0
+                }
+            },
+        })
+
+    for _ in range(KachakaApiClientByZenoh.MAX_IGNORED_MISMATCHES * 2):
+        asyncio.run(node.publish_result())
+        assert node.current_command_id == 'own-move-active-2'
+
+    assert published_payloads(node) == []
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-own-move-2',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node.task_id is None
+    assert node.current_command_id != 'ext-move-persistent'
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -740,6 +740,151 @@ def test_final_pose_mismatch_is_not_reported_as_success() -> None:
     assert published_payloads(node) == [{'id': 'cmd-pose', 'is_completed': True, 'success': False}]
 
 
+def test_bound_command_missing_state_command_id_is_not_treated_as_progress() -> None:
+    """A RUNNING GetCommandState response missing commandId must not be accepted as our bound command.
+
+    Codex re-review ISS34-040 blocking-A: publish_result() only rejected a
+    *non-empty* mismatched commandId on the state poll; an empty/missing one
+    slipped through unchecked and was treated as progress on the active
+    task. Kachaka API 3.14.4.0's own client wrapper requires
+    result.command_id == response.command_id while waiting for completion,
+    so an empty id here must fail closed the same as any other mismatch,
+    not be silently accepted.
+    """
+    node = make_node()
+    node.task_id = 'cmd-bound'
+    node.is_async_command = True
+    node.saw_running = False
+    node.current_command_id = 'own-id-1'
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_dispatched_at = time.monotonic()
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': None,
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'moveToPoseCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert node.saw_running is False
+    assert published_payloads(node) == []
+
+
+def test_bound_command_missing_result_command_id_does_not_report_success() -> None:
+    """A GetLastCommandResult response missing commandId must never be accepted as our completion.
+
+    Direct regression for Codex re-review ISS34-040 blocking-A: the
+    previous code only rejected a *non-empty* mismatched result commandId
+    and otherwise fell through to check type/map/target, so a stale or
+    external result with no commandId at all -- but a matching type and
+    target -- was reported as this task's own success (Codex's simulation
+    reproduced exactly this: published=[{id: rmf-own, is_completed: true,
+    success: true}]). Ownership requires an exact commandId match;
+    empty/missing must fail closed like any other mismatch.
+    """
+    node = make_node()
+    node.task_id = 'cmd-ok'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'own-id-2'
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_target_map_name = '8F'
+    node.command_target_pose = Pose(1.0, 1.0, 0.0)
+    node.last_pose = Pose(1.0, 1.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'own-id-2',
+        'state': 'COMMAND_STATE_UNKNOWN'
+    })
+    node._get_last_command_result_response = MagicMock(return_value={
+        'commandId': None,
+        'result': {
+            'success': True,
+            'errorCode': 0
+        },
+        'command': {
+            'moveToPoseCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert published_payloads(node) == []
+
+
+def test_sync_switch_map_own_id_snapshot_is_not_reconciled_as_external() -> None:
+    """A RUNNING command observed during a synchronous switch_map dispatch is never reconciled.
+
+    Reproduces Codex re-review ISS34-040 blocking-B: _reconcile_pending_dispatch_snapshot()
+    used to run for every dispatch, including synchronous ones (switch_map)
+    that never capture an ownership id at all. A monitor_external_control()
+    poll during such a dispatch that observed the dispatch's own in-flight
+    command_id would, once (mis)reconciled, treat that own id as external
+    and set external_control_active=True right after the dispatch's own
+    success was published -- incorrectly rejecting subsequent RMF commands
+    with external_busy until the next live poll cleared it.
+
+    Drives dispatch (_execute_command) and detection
+    (monitor_external_control) on real threads: the mocked
+    _execute_switch_map_sync pauses on an Event (mirroring the real gRPC
+    work), which is the exact window where dispatching=True and no
+    ownership id exists to compare a snapshot against.
+    """
+    node = make_node(client_methods=['switch_map'])
+    node.method_mapping = {}
+
+    reached_dispatch = threading.Event()
+    proceed_with_dispatch = threading.Event()
+
+    def racing_switch_map(_args: dict, _task_id: Optional[str]) -> None:
+        reached_dispatch.set()
+        proceed_with_dispatch.wait(timeout=2.0)
+        node._publish_command_completion(success=True, error_code=0, task_id='cmd-switch-map')
+
+    node._execute_switch_map_sync = MagicMock(side_effect=racing_switch_map)
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'own-switch-map-id',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToLocationCommand': {
+                    'targetLocationId': 'somewhere'
+                }
+            },
+        })
+
+    dispatch_thread = threading.Thread(
+        target=node._execute_command,
+        args=({
+            'id': 'cmd-switch-map',
+            'method': 'switch_map',
+            'args': {}
+        },),
+    )
+    dispatch_thread.start()
+    assert reached_dispatch.wait(timeout=2.0), 'dispatch never reached switch_map execution'
+    assert node.dispatching is True
+
+    # monitor observes the dispatch's own in-flight command as RUNNING while
+    # dispatching=True; it must defer, not judge ownership yet.
+    asyncio.run(node.monitor_external_control())
+    assert node.external_control_active is False
+    assert node._pending_dispatch_snapshot_id == 'own-switch-map-id'
+
+    proceed_with_dispatch.set()
+    dispatch_thread.join(timeout=2.0)
+    assert not dispatch_thread.is_alive()
+    assert node.dispatching is False
+
+    # The switch_map's own success was published, and reconciliation must
+    # never have run for it: no bogus external detection.
+    assert published_payloads(node) == [{'id': 'cmd-switch-map', 'is_completed': True, 'success': True}]
+    assert node.external_control_active is False
+    assert node._pending_dispatch_snapshot_id is None
+
+
 def test_wrong_type_running_command_is_not_bound_when_dispatch_lacked_command_id() -> None:
     """publish_result() never binds current_command_id while it is unset, regardless of command type.
 

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -31,9 +31,11 @@ import sys
 import threading
 import time
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import MagicMock
 
 import grpc
+from kachaka_api.generated import kachaka_api_pb2 as pb2
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'scripts'))
 
@@ -138,6 +140,21 @@ def published_payloads(node: KachakaApiClientByZenoh) -> list:
 def published_state_payloads(node: KachakaApiClientByZenoh) -> list:
     """Return all payloads published on the unified robots/*/state publisher."""
     return [call.args[1] for call in node._publish_to_zenoh.call_args_list if call.args[0] is node.state_pub]
+
+
+def stub_start_command_response(command_id: Optional[str] = None, success: bool = True, error_code: int = 0) -> object:
+    """Build a pb2.StartCommandResponse for mocking kachaka_client.stub.StartCommand.
+
+    A real protobuf message (not a dict/SimpleNamespace) is required so
+    _to_dict()'s module-name check routes it through MessageToDict, exactly
+    as it would for the genuine gRPC stub response.
+    """
+    response = pb2.StartCommandResponse()
+    response.result.success = success
+    response.result.error_code = error_code
+    if command_id is not None:
+        response.command_id = command_id
+    return response
 
 
 # ---------------------------------------------------------------------------
@@ -339,7 +356,7 @@ def test_move_to_pose_short_circuits_across_pi_seam() -> None:
 def test_move_to_pose_does_not_short_circuit_without_map_name() -> None:
     """A missing map_name never short-circuits, even at zero distance (Plan §7.1)."""
     node = make_node(client_methods=['move_to_pose'])
-    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-nomap'})
+    node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-nomap'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node._fetch_robot_map_name = MagicMock(return_value='8F')
 
@@ -355,14 +372,14 @@ def test_move_to_pose_does_not_short_circuit_without_map_name() -> None:
     })
 
     node._fetch_robot_map_name.assert_not_called()
-    node._execute_sync_method.assert_called_once()
+    node._execute_async_stub_dispatch.assert_called_once()
     assert published_payloads(node) == []
 
 
 def test_move_to_pose_short_circuit_requires_fresh_floor_match() -> None:
     """A stale cache match is not enough: a fresh floor mismatch dispatches instead of short-circuiting."""
     node = make_node(client_methods=['move_to_pose'])
-    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-stale'})
+    node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-stale'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     # Cache says 8F (matches the request) but the robot has actually switched to 9F
     # since the last telemetry read -- exactly the switch_map race in concern (a).
@@ -381,14 +398,14 @@ def test_move_to_pose_short_circuit_requires_fresh_floor_match() -> None:
     })
 
     node._fetch_robot_map_name.assert_called_once()
-    node._execute_sync_method.assert_called_once()
+    node._execute_async_stub_dispatch.assert_called_once()
     assert published_payloads(node) == []
 
 
 def test_move_to_pose_short_circuits_at_exact_boundary() -> None:
     """Exactly 0.15m / 0.10rad (the inclusive boundary) still short-circuits."""
     node = make_node(client_methods=['move_to_pose'])
-    node._execute_sync_method = MagicMock()
+    node._execute_async_stub_dispatch = MagicMock()
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
     node._fetch_robot_map_name = MagicMock(return_value='8F')
@@ -404,14 +421,14 @@ def test_move_to_pose_short_circuits_at_exact_boundary() -> None:
         },
     })
 
-    node._execute_sync_method.assert_not_called()
+    node._execute_async_stub_dispatch.assert_not_called()
     assert published_payloads(node) == [{'id': 'cmd-boundary', 'is_completed': True, 'success': True}]
 
 
 def test_move_to_pose_dispatches_when_only_yaw_exceeds_tolerance() -> None:
     """Distance within tolerance but yaw beyond it dispatches a normal command."""
     node = make_node(client_methods=['move_to_pose'])
-    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-yaw'})
+    node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-yaw'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
     node._fetch_robot_map_name = MagicMock(return_value='8F')
@@ -430,14 +447,14 @@ def test_move_to_pose_dispatches_when_only_yaw_exceeds_tolerance() -> None:
     # yaw alone exceeds noop_yaw_tolerance (0.10rad); the shortcut's cheap
     # near-target check must reject it before any fresh floor re-query.
     node._fetch_robot_map_name.assert_not_called()
-    node._execute_sync_method.assert_called_once()
+    node._execute_async_stub_dispatch.assert_called_once()
     assert published_payloads(node) == []
 
 
 def test_move_to_pose_dispatches_when_outside_noop_tolerance() -> None:
     """A move beyond the noop tolerance is dispatched to Kachaka as normal."""
     node = make_node(client_methods=['move_to_pose'])
-    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-move'})
+    node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-move'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
 
@@ -452,13 +469,13 @@ def test_move_to_pose_dispatches_when_outside_noop_tolerance() -> None:
         },
     })
 
-    node._execute_sync_method.assert_called_once()
-    assert node._execute_sync_method.call_args.kwargs['task_id'] == 'cmd-move'
+    node._execute_async_stub_dispatch.assert_called_once()
+    assert node._execute_async_stub_dispatch.call_args.kwargs['task_id'] == 'cmd-move'
     assert node.expected_kachaka_method == 'move_to_pose'
     assert node.command_target_map_name == '8F'
     assert node.command_target_pose == Pose(1.0, 0.0, 0.0)
     # The noop short-circuit must not have published a completion itself;
-    # _execute_sync_method (mocked here) owns publishing for the dispatch path.
+    # _execute_async_stub_dispatch (mocked here) owns publishing for the dispatch path.
     assert published_payloads(node) == []
 
 
@@ -801,14 +818,22 @@ def test_same_type_running_command_with_matching_target_still_binds() -> None:
 
 
 def test_command_dispatched_at_set_only_after_successful_dispatch() -> None:
-    """command_dispatched_at is set at dispatch success, not before grpc_connection_check."""
-    node = make_node(client_methods=['move_to_pose'])
-    node.is_async_command = True
+    """command_dispatched_at is set at dispatch success, not before grpc_connection_check.
+
+    move_to_pose/return_home now dispatch via stub.StartCommand() directly
+    (_execute_async_stub_dispatch) instead of the high-level wrapper, so the
+    mock target moved from kachaka_client.move_to_pose to
+    kachaka_client.stub.StartCommand (Issue #34 Plan §7.3/§7.4, Codex
+    re-review ISS34-010 blocking-3).
+    """
+    node = make_node(client_methods=['stub'])
+    node.is_async_command = False
     node.command_dispatched_at = None
     node.grpc_connection_check = MagicMock(return_value=True)
-    node.kachaka_client.move_to_pose.configure_mock(return_value={'success': True, 'errorCode': 0})
+    node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(
+        command_id='grpc-dispatch'))
 
-    node._execute_sync_method('move_to_pose', {'x': 1.0, 'y': 0.0, 'yaw': 0.0}, task_id='cmd-dispatch')
+    node._execute_async_stub_dispatch('move_to_pose', {'x': 1.0, 'y': 0.0, 'yaw': 0.0}, task_id='cmd-dispatch')
 
     assert node.command_dispatched_at is not None
     assert time.monotonic() - node.command_dispatched_at < 1.0
@@ -816,13 +841,18 @@ def test_command_dispatched_at_set_only_after_successful_dispatch() -> None:
 
 def test_command_dispatched_at_stays_none_when_connection_check_fails() -> None:
     """A failed grpc_connection_check never sets command_dispatched_at."""
-    node = make_node(client_methods=['move_to_pose'])
-    node.is_async_command = True
+    node = make_node(client_methods=['stub'])
+    node.is_async_command = False
     node.command_dispatched_at = None
     node.grpc_connection_check = MagicMock(return_value=False)
 
     try:
-        node._execute_sync_method('move_to_pose', {'x': 1.0, 'y': 0.0, 'yaw': 0.0}, task_id='cmd-dispatch-fail')
+        node._execute_async_stub_dispatch('move_to_pose', {
+            'x': 1.0,
+            'y': 0.0,
+            'yaw': 0.0
+        },
+                                          task_id='cmd-dispatch-fail')
     except ConnectionError:
         pass
 
@@ -860,11 +890,24 @@ def test_external_return_home_preempts_active_rmf_task() -> None:
 
 
 def test_own_dock_return_home_is_not_treated_as_external() -> None:
-    """RMF's own dock (return_home) command is never classified as external."""
-    node = make_node()
-    node.task_id = 'cmd-dock'
-    node.last_command = {'id': 'cmd-dock', 'method': 'dock', 'args': {}}
-    node.command_dispatched_at = time.monotonic()
+    """RMF's own dispatched dock (return_home) is never classified as external.
+
+    Stub-direct dispatch (_execute_async_stub_dispatch) captures command_id
+    synchronously at dispatch time, so ownership is decided purely by ID
+    equality from dispatch onward -- even within running_state_wait of the
+    dispatch (Issue #34 Plan §7.3/§7.4, Codex re-review ISS34-010
+    blocking-3). Goes through the real dispatch (_execute_command) and the
+    real detection path (monitor_external_control), not manually-set state.
+    """
+    node = make_node(client_methods=['return_home', 'stub'])
+    node.method_mapping = {'dock': 'return_home'}
+    node.grpc_connection_check = MagicMock(return_value=True)
+    node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(
+        command_id='own-return-home-1'))
+
+    node._execute_command({'id': 'cmd-dock', 'method': 'dock', 'args': {}})
+    assert node.current_command_id == 'own-return-home-1'
+
     node._get_command_state_response = MagicMock(return_value={
         'commandId': 'own-return-home-1',
         'state': 'COMMAND_STATE_RUNNING',
@@ -883,17 +926,23 @@ def test_own_dock_return_home_is_not_treated_as_external() -> None:
 def test_external_return_home_id_conflict_with_rmf_dock_is_not_reported_as_success() -> None:
     """An external returnHome racing our own dock dispatch is never confused for our dock's success.
 
-    Reproduces Codex review ISS34-006's blocking scenario: our own dock is
-    dispatched but has not yet bound a command_id, an externally-triggered
-    returnHome is RUNNING under a different id, and the dispatch grace period
-    (running_state_wait) has elapsed without our own RUNNING appearing. The
-    external command must be recognized as external (preempting our task with
-    external_preempted), not attributed to our dock as a success.
+    Reproduces Codex re-review ISS34-010 blocking-3: our own dock is
+    dispatched and binds a command_id synchronously via stub-direct dispatch,
+    but a different, externally-triggered returnHome is observed RUNNING
+    under a different id -- well inside running_state_wait, the very window
+    the previous fallback treated an unbound id as plausibly ours. The
+    external command must still be recognized as external (preempting our
+    task with external_preempted), not attributed to our dock as a success.
     """
-    node = make_node()
-    node.task_id = 'cmd-dock'
-    node.last_command = {'id': 'cmd-dock', 'method': 'dock', 'args': {}}
-    node.command_dispatched_at = time.monotonic() - (node.running_state_wait + 1.0)
+    node = make_node(client_methods=['return_home', 'stub'])
+    node.method_mapping = {'dock': 'return_home'}
+    node.grpc_connection_check = MagicMock(return_value=True)
+    node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(
+        command_id='own-dock-id'))
+
+    node._execute_command({'id': 'cmd-dock', 'method': 'dock', 'args': {}})
+    assert node.current_command_id == 'own-dock-id'
+
     node._get_command_state_response = MagicMock(return_value={
         'commandId': 'ext-return-home-2',
         'state': 'COMMAND_STATE_RUNNING',
@@ -924,6 +973,43 @@ def test_external_return_home_id_conflict_with_rmf_dock_is_not_reported_as_succe
     assert node.last_command_result == CommandCompletion('cmd-dock', True, False, -8, 'external_preempted')
 
 
+def test_external_return_home_when_own_dispatch_never_bound_id_is_detected_as_external() -> None:
+    """A returnHome is treated as external when our own dock dispatch never bound a command_id.
+
+    Defensive coverage for Issue #34 Plan §7.4 blocking-3: even if
+    StartCommandResponse carried no command_id (should not normally happen
+    once a stub-direct dispatch reports success), an unbound own
+    command_id must never be treated as plausibly ours -- unlike the
+    previous running_state_wait-window fallback, which assumed an unbound
+    id was ours for the whole window.
+    """
+    node = make_node(client_methods=['return_home', 'stub'])
+    node.method_mapping = {'dock': 'return_home'}
+    node.grpc_connection_check = MagicMock(return_value=True)
+    node.kachaka_client.stub.StartCommand = MagicMock(return_value=stub_start_command_response(command_id=None))
+
+    node._execute_command({'id': 'cmd-dock-3', 'method': 'dock', 'args': {}})
+    assert node.current_command_id is None
+
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-return-home-3',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-dock-3',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+
+
 def test_recently_completed_dock_return_home_is_not_treated_as_external() -> None:
     """A dock that just completed is not mistaken for external control (concern (b)).
 
@@ -950,10 +1036,10 @@ def test_recently_completed_dock_return_home_is_not_treated_as_external() -> Non
     assert published_payloads(node) == []
 
     # A following RMF move must not be rejected with external_busy.
-    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-next-move'})
+    node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-next-move'})
     node._execute_command({'id': 'cmd-next-move', 'method': 'move_to_pose', 'args': {'x': 5.0, 'y': 5.0}})
     assert published_payloads(node) == []
-    node._execute_sync_method.assert_called_once()
+    node._execute_async_stub_dispatch.assert_called_once()
 
 
 def test_own_return_home_retention_recorded_on_dock_completion() -> None:
@@ -1028,12 +1114,12 @@ def test_own_return_home_retention_recorded_via_publish_result_completion_path()
 def test_external_control_active_rejects_new_rmf_command_with_external_busy() -> None:
     """An RMF command arriving while external control is active is rejected, not sent to Kachaka."""
     node = make_node(client_methods=['move_to_pose'])
-    node._execute_sync_method = MagicMock()
+    node._execute_async_stub_dispatch = MagicMock()
     node.external_control_active = True
 
     node._execute_command({'id': 'cmd-during-external', 'method': 'move_to_pose', 'args': {'x': 5.0, 'y': 5.0}})
 
-    node._execute_sync_method.assert_not_called()
+    node._execute_async_stub_dispatch.assert_not_called()
     assert published_payloads(node) == [{
         'id': 'cmd-during-external',
         'is_completed': True,

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -121,6 +121,9 @@ def make_node(client_methods: list = []) -> KachakaApiClientByZenoh:
     node.command_target_pose = None
     node.external_control_active = False
     node._external_command_id = None
+    node.own_return_home_retention = 5.0
+    node._recently_own_return_home_id = None
+    node._recently_own_return_home_until = None
     node._state_seq = 0
     return node
 
@@ -289,6 +292,7 @@ def test_move_to_pose_short_circuits_within_noop_tolerance() -> None:
     node._execute_sync_method = MagicMock()
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._fetch_robot_map_name = MagicMock(return_value='8F')
 
     node._execute_command({
         'id': 'cmd-noop',
@@ -302,6 +306,9 @@ def test_move_to_pose_short_circuits_within_noop_tolerance() -> None:
     })
 
     node._execute_sync_method.assert_not_called()
+    # The shortcut must always re-query the floor, even though the cache already
+    # agreed with the requested map_name (Issue #34 Plan §7.1 concern (a)).
+    node._fetch_robot_map_name.assert_called_once()
     assert published_payloads(node) == [{'id': 'cmd-noop', 'is_completed': True, 'success': True}]
     assert node.task_id is None
 
@@ -311,6 +318,8 @@ def test_move_to_pose_short_circuits_across_pi_seam() -> None:
     node = make_node(client_methods=['move_to_pose'])
     node._execute_sync_method = MagicMock()
     node.last_pose = Pose(0.0, 0.0, 3.10)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._fetch_robot_map_name = MagicMock(return_value='8F')
 
     node._execute_command({
         'id': 'cmd-noop-wrap',
@@ -319,12 +328,110 @@ def test_move_to_pose_short_circuits_across_pi_seam() -> None:
             'x': 0.0,
             'y': 0.0,
             'yaw': -3.10,
-            'map_name': None
+            'map_name': '8F'
         },
     })
 
     node._execute_sync_method.assert_not_called()
     assert published_payloads(node) == [{'id': 'cmd-noop-wrap', 'is_completed': True, 'success': True}]
+
+
+def test_move_to_pose_does_not_short_circuit_without_map_name() -> None:
+    """A missing map_name never short-circuits, even at zero distance (Plan §7.1)."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-nomap'})
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    node._fetch_robot_map_name = MagicMock(return_value='8F')
+
+    node._execute_command({
+        'id': 'cmd-nomap',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 0.0,
+            'y': 0.0,
+            'yaw': 0.0,
+            'map_name': None
+        },
+    })
+
+    node._fetch_robot_map_name.assert_not_called()
+    node._execute_sync_method.assert_called_once()
+    assert published_payloads(node) == []
+
+
+def test_move_to_pose_short_circuit_requires_fresh_floor_match() -> None:
+    """A stale cache match is not enough: a fresh floor mismatch dispatches instead of short-circuiting."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-stale'})
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    # Cache says 8F (matches the request) but the robot has actually switched to 9F
+    # since the last telemetry read -- exactly the switch_map race in concern (a).
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._fetch_robot_map_name = MagicMock(return_value='9F')
+
+    node._execute_command({
+        'id': 'cmd-stale-floor',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 0.0,
+            'y': 0.0,
+            'yaw': 0.0,
+            'map_name': '8F'
+        },
+    })
+
+    node._fetch_robot_map_name.assert_called_once()
+    node._execute_sync_method.assert_called_once()
+    assert published_payloads(node) == []
+
+
+def test_move_to_pose_short_circuits_at_exact_boundary() -> None:
+    """Exactly 0.15m / 0.10rad (the inclusive boundary) still short-circuits."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock()
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._fetch_robot_map_name = MagicMock(return_value='8F')
+
+    node._execute_command({
+        'id': 'cmd-boundary',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 0.15,
+            'y': 0.0,
+            'yaw': 0.10,
+            'map_name': '8F'
+        },
+    })
+
+    node._execute_sync_method.assert_not_called()
+    assert published_payloads(node) == [{'id': 'cmd-boundary', 'is_completed': True, 'success': True}]
+
+
+def test_move_to_pose_dispatches_when_only_yaw_exceeds_tolerance() -> None:
+    """Distance within tolerance but yaw beyond it dispatches a normal command."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-yaw'})
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._fetch_robot_map_name = MagicMock(return_value='8F')
+
+    node._execute_command({
+        'id': 'cmd-yaw-out',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 0.0,
+            'y': 0.0,
+            'yaw': 0.11,
+            'map_name': '8F'
+        },
+    })
+
+    # yaw alone exceeds noop_yaw_tolerance (0.10rad); the shortcut's cheap
+    # near-target check must reject it before any fresh floor re-query.
+    node._fetch_robot_map_name.assert_not_called()
+    node._execute_sync_method.assert_called_once()
+    assert published_payloads(node) == []
 
 
 def test_move_to_pose_dispatches_when_outside_noop_tolerance() -> None:
@@ -533,6 +640,126 @@ def test_matching_command_type_and_floor_reports_success() -> None:
     assert published_payloads(node) == [{'id': 'cmd-ok', 'is_completed': True, 'success': True}]
 
 
+def test_final_pose_mismatch_is_not_reported_as_success() -> None:
+    """A same-ID, same-type, same-floor success far from the target pose is rejected."""
+    node = make_node()
+    node.task_id = 'cmd-pose'
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'grpc-pose'
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_target_map_name = '8F'
+    node.command_target_pose = Pose(10.0, 10.0, 0.0)
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'grpc-pose',
+        'state': 'COMMAND_STATE_UNKNOWN'
+    })
+    node._get_last_command_result_response = MagicMock(return_value={
+        'commandId': 'grpc-pose',
+        'result': {
+            'success': True,
+            'errorCode': 0
+        },
+        'command': {
+            'moveToPoseCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert published_payloads(node) == [{'id': 'cmd-pose', 'is_completed': True, 'success': False}]
+
+
+def test_wrong_type_running_command_is_not_bound_when_dispatch_lacked_command_id() -> None:
+    """A StartCommand response without commandId must not let a wrong-type RUNNING command bind later.
+
+    Reproduces Codex review ISS34-006's blocking finding: high-level
+    StartCommand often returns a bare Result with no commandId, so
+    current_command_id stays unbound after dispatch. Binding must still
+    require the observed command's type to match what was dispatched.
+    """
+    node = make_node()
+    node.task_id = 'cmd-nobind'
+    node.is_async_command = True
+    node.saw_running = False
+    node.current_command_id = None  # StartCommand response carried no commandId
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_dispatched_at = time.monotonic()
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'unrelated-running-1',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert node.current_command_id is None
+    assert node.saw_running is False
+    assert published_payloads(node) == []
+
+
+def test_correct_type_running_command_binds_when_dispatch_lacked_command_id() -> None:
+    """A matching-type RUNNING command still binds normally after a commandId-less dispatch."""
+    node = make_node()
+    node.task_id = 'cmd-bind-ok'
+    node.is_async_command = True
+    node.saw_running = False
+    node.current_command_id = None
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_dispatched_at = time.monotonic()
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'grpc-bind-ok',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'moveToPoseCommand': {}
+        },
+    })
+
+    asyncio.run(node.publish_result())
+
+    assert node.current_command_id == 'grpc-bind-ok'
+    assert node.saw_running is True
+    assert published_payloads(node) == [{'id': 'cmd-bind-ok', 'is_completed': False}]
+
+
+# ---------------------------------------------------------------------------
+# Issue #34 Plan §7.2: command_dispatched_at origin (Codex review non-blocking finding)
+# ---------------------------------------------------------------------------
+
+
+def test_command_dispatched_at_set_only_after_successful_dispatch() -> None:
+    """command_dispatched_at is set at dispatch success, not before grpc_connection_check."""
+    node = make_node(client_methods=['move_to_pose'])
+    node.is_async_command = True
+    node.command_dispatched_at = None
+    node.grpc_connection_check = MagicMock(return_value=True)
+    node.kachaka_client.move_to_pose.configure_mock(return_value={'success': True, 'errorCode': 0})
+
+    node._execute_sync_method('move_to_pose', {'x': 1.0, 'y': 0.0, 'yaw': 0.0}, task_id='cmd-dispatch')
+
+    assert node.command_dispatched_at is not None
+    assert time.monotonic() - node.command_dispatched_at < 1.0
+
+
+def test_command_dispatched_at_stays_none_when_connection_check_fails() -> None:
+    """A failed grpc_connection_check never sets command_dispatched_at."""
+    node = make_node(client_methods=['move_to_pose'])
+    node.is_async_command = True
+    node.command_dispatched_at = None
+    node.grpc_connection_check = MagicMock(return_value=False)
+
+    try:
+        node._execute_sync_method('move_to_pose', {'x': 1.0, 'y': 0.0, 'yaw': 0.0}, task_id='cmd-dispatch-fail')
+    except ConnectionError:
+        pass
+
+    assert node.command_dispatched_at is None
+
+
 # ---------------------------------------------------------------------------
 # Issue #34 Plan §7.4: external returnHome
 # ---------------------------------------------------------------------------
@@ -568,6 +795,7 @@ def test_own_dock_return_home_is_not_treated_as_external() -> None:
     node = make_node()
     node.task_id = 'cmd-dock'
     node.last_command = {'id': 'cmd-dock', 'method': 'dock', 'args': {}}
+    node.command_dispatched_at = time.monotonic()
     node._get_command_state_response = MagicMock(return_value={
         'commandId': 'own-return-home-1',
         'state': 'COMMAND_STATE_RUNNING',
@@ -581,6 +809,97 @@ def test_own_dock_return_home_is_not_treated_as_external() -> None:
     assert published_payloads(node) == []
     assert node.external_control_active is False
     assert node.task_id == 'cmd-dock'
+
+
+def test_external_return_home_id_conflict_with_rmf_dock_is_not_reported_as_success() -> None:
+    """An external returnHome racing our own dock dispatch is never confused for our dock's success.
+
+    Reproduces Codex review ISS34-006's blocking scenario: our own dock is
+    dispatched but has not yet bound a command_id, an externally-triggered
+    returnHome is RUNNING under a different id, and the dispatch grace period
+    (running_state_wait) has elapsed without our own RUNNING appearing. The
+    external command must be recognized as external (preempting our task with
+    external_preempted), not attributed to our dock as a success.
+    """
+    node = make_node()
+    node.task_id = 'cmd-dock'
+    node.last_command = {'id': 'cmd-dock', 'method': 'dock', 'args': {}}
+    node.command_dispatched_at = time.monotonic() - (node.running_state_wait + 1.0)
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-return-home-2',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert published_payloads(node) == [{
+        'id': 'cmd-dock',
+        'is_completed': True,
+        'success': False,
+        'reason': 'external_preempted',
+    }]
+    assert node.external_control_active is True
+    assert node.task_id is None
+
+    # Even if the external returnHome later reports success, there is no
+    # active task left to misattribute it to: publish_result has nothing to
+    # poll for once task_id has been cleared by the preemption above.
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'ext-return-home-2',
+        'state': 'COMMAND_STATE_SUCCEEDED'
+    })
+    asyncio.run(node.publish_result())
+    assert node.last_command_result == CommandCompletion('cmd-dock', True, False, -8, 'external_preempted')
+
+
+def test_recently_completed_dock_return_home_is_not_treated_as_external() -> None:
+    """A dock that just completed is not mistaken for external control (concern (b)).
+
+    Kachaka can still report a briefly-lingering RUNNING return_home right
+    after our own dock completes; the short retention grace period recognizes
+    it as ours so a following RMF move is not rejected with external_busy.
+    """
+    node = make_node(client_methods=['move_to_pose'])
+    node.task_id = None  # dock already completed; task_id was reset
+    node.last_command = {'id': 'cmd-dock-done', 'method': 'dock', 'args': {}}
+    node._recently_own_return_home_id = 'own-return-home-2'
+    node._recently_own_return_home_until = time.monotonic() + node.own_return_home_retention
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'own-return-home-2',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+
+    asyncio.run(node.monitor_external_control())
+
+    assert node.external_control_active is False
+    assert published_payloads(node) == []
+
+    # A following RMF move must not be rejected with external_busy.
+    node._execute_sync_method = MagicMock(return_value={'commandId': 'grpc-next-move'})
+    node._execute_command({'id': 'cmd-next-move', 'method': 'move_to_pose', 'args': {'x': 5.0, 'y': 5.0}})
+    assert published_payloads(node) == []
+    node._execute_sync_method.assert_called_once()
+
+
+def test_own_return_home_retention_recorded_on_dock_completion() -> None:
+    """A successful dock completion records its command_id for the retention grace period."""
+    node = make_node()
+    node.task_id = 'cmd-dock-3'
+    node.last_command = {'id': 'cmd-dock-3', 'method': 'dock', 'args': {}}
+    node.current_command_id = 'own-return-home-3'
+
+    assert node._publish_command_completion(success=True, error_code=0) is True
+
+    assert node._recently_own_return_home_id == 'own-return-home-3'
+    assert node._recently_own_return_home_until is not None
+    assert node._recently_own_return_home_until > time.monotonic()
+    assert node.task_id is None
 
 
 def test_external_control_active_rejects_new_rmf_command_with_external_busy() -> None:

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -107,6 +107,7 @@ def make_node(client_methods: list = []) -> KachakaApiClientByZenoh:
     node.kachaka_client = MagicMock(spec=client_methods)
     # Issue #34 Step 2 state: near-distance short-circuit, split timeouts,
     # command matching, external returnHome tracking, unified state seq.
+    node.noop_enabled = False
     node.noop_distance_tolerance = 0.15
     node.noop_yaw_tolerance = 0.10
     node.progress_distance_delta = 0.02
@@ -306,6 +307,7 @@ def test_stale_completion_does_not_reset_active_task() -> None:
 def test_move_to_pose_short_circuits_within_noop_tolerance() -> None:
     """A 14.9cm move within yaw tolerance succeeds once without calling Kachaka."""
     node = make_node(client_methods=['move_to_pose'])
+    node.noop_enabled = True
     node._execute_sync_method = MagicMock()
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
@@ -333,6 +335,7 @@ def test_move_to_pose_short_circuits_within_noop_tolerance() -> None:
 def test_move_to_pose_short_circuits_across_pi_seam() -> None:
     """Yaw tolerance is checked after normalizing across the +/-pi wraparound."""
     node = make_node(client_methods=['move_to_pose'])
+    node.noop_enabled = True
     node._execute_sync_method = MagicMock()
     node.last_pose = Pose(0.0, 0.0, 3.10)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
@@ -356,6 +359,7 @@ def test_move_to_pose_short_circuits_across_pi_seam() -> None:
 def test_move_to_pose_does_not_short_circuit_without_map_name() -> None:
     """A missing map_name never short-circuits, even at zero distance (Plan §7.1)."""
     node = make_node(client_methods=['move_to_pose'])
+    node.noop_enabled = True
     node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-nomap'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node._fetch_robot_map_name = MagicMock(return_value='8F')
@@ -379,6 +383,7 @@ def test_move_to_pose_does_not_short_circuit_without_map_name() -> None:
 def test_move_to_pose_short_circuit_requires_fresh_floor_match() -> None:
     """A stale cache match is not enough: a fresh floor mismatch dispatches instead of short-circuiting."""
     node = make_node(client_methods=['move_to_pose'])
+    node.noop_enabled = True
     node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-stale'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     # Cache says 8F (matches the request) but the robot has actually switched to 9F
@@ -405,6 +410,7 @@ def test_move_to_pose_short_circuit_requires_fresh_floor_match() -> None:
 def test_move_to_pose_short_circuits_at_exact_boundary() -> None:
     """Exactly 0.15m / 0.10rad (the inclusive boundary) still short-circuits."""
     node = make_node(client_methods=['move_to_pose'])
+    node.noop_enabled = True
     node._execute_async_stub_dispatch = MagicMock()
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
@@ -428,6 +434,7 @@ def test_move_to_pose_short_circuits_at_exact_boundary() -> None:
 def test_move_to_pose_dispatches_when_only_yaw_exceeds_tolerance() -> None:
     """Distance within tolerance but yaw beyond it dispatches a normal command."""
     node = make_node(client_methods=['move_to_pose'])
+    node.noop_enabled = True
     node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-yaw'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
@@ -454,6 +461,7 @@ def test_move_to_pose_dispatches_when_only_yaw_exceeds_tolerance() -> None:
 def test_move_to_pose_dispatches_when_outside_noop_tolerance() -> None:
     """A move beyond the noop tolerance is dispatched to Kachaka as normal."""
     node = make_node(client_methods=['move_to_pose'])
+    node.noop_enabled = True
     node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-move'})
     node.last_pose = Pose(0.0, 0.0, 0.0)
     node.map_state = MapState.initial().with_telemetry_map_name('8F')
@@ -476,6 +484,37 @@ def test_move_to_pose_dispatches_when_outside_noop_tolerance() -> None:
     assert node.command_target_pose == Pose(1.0, 0.0, 0.0)
     # The noop short-circuit must not have published a completion itself;
     # _execute_async_stub_dispatch (mocked here) owns publishing for the dispatch path.
+    assert published_payloads(node) == []
+
+
+def test_move_to_pose_dispatches_when_noop_disabled_by_default() -> None:
+    """With noop_enabled left at its default (False), an in-tolerance move still dispatches normally."""
+    node = make_node(client_methods=['move_to_pose'])
+    node._execute_async_stub_dispatch = MagicMock(return_value={'commandId': 'grpc-noop-disabled'})
+    node._is_near_target = MagicMock()
+    node._fresh_floor_matches = MagicMock()
+    node.last_pose = Pose(0.0, 0.0, 0.0)
+    node.map_state = MapState.initial().with_telemetry_map_name('8F')
+
+    node._execute_command({
+        'id': 'cmd-noop-disabled',
+        'method': 'move_to_pose',
+        'args': {
+            'x': 0.0,
+            'y': 0.0,
+            'yaw': 0.0,
+            'map_name': '8F'
+        },
+    })
+
+    # noop_enabled=False must short-circuit-evaluate the gate before
+    # _is_near_target()/_fresh_floor_matches() are called at all.
+    node._is_near_target.assert_not_called()
+    node._fresh_floor_matches.assert_not_called()
+    node._execute_async_stub_dispatch.assert_called_once()
+    assert node._execute_async_stub_dispatch.call_args.kwargs['task_id'] == 'cmd-noop-disabled'
+    assert node.expected_kachaka_method == 'move_to_pose'
+    assert node.command_target_pose == Pose(0.0, 0.0, 0.0)
     assert published_payloads(node) == []
 
 

--- a/test/test_command_lifecycle.py
+++ b/test/test_command_lifecycle.py
@@ -726,6 +726,75 @@ def test_correct_type_running_command_binds_when_dispatch_lacked_command_id() ->
     assert published_payloads(node) == [{'id': 'cmd-bind-ok', 'is_completed': False}]
 
 
+def test_same_type_running_command_with_mismatched_target_is_not_bound() -> None:
+    """A same-type RUNNING move_to_pose toward a different target is not bound to our task.
+
+    Reproduces Codex re-review ISS34-010 blocking-2: the previous bind
+    condition checked only that the observed command's type matched
+    (moveToPoseCommand), so a same-type command started by someone else (or
+    a stale one) toward a different destination would still bind and its
+    later success would be reported to RMF as our task's success. Binding
+    must also confirm the observed command's own target matches what we
+    dispatched (Issue #34 Plan §7.3).
+    """
+    node = make_node()
+    node.task_id = 'cmd-ext-move'
+    node.is_async_command = True
+    node.saw_running = False
+    node.current_command_id = None
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_dispatched_at = time.monotonic()
+    node.command_target_pose = Pose(1.0, 1.0, 0.0)
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'external-move-1',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 5.0,
+                    'y': 5.0,
+                    'yaw': 0.0
+                },
+            },
+        })
+
+    asyncio.run(node.publish_result())
+
+    assert node.current_command_id is None
+    assert node.saw_running is False
+    assert published_payloads(node) == []
+
+
+def test_same_type_running_command_with_matching_target_still_binds() -> None:
+    """A same-type RUNNING move_to_pose whose own target matches ours still binds normally."""
+    node = make_node()
+    node.task_id = 'cmd-own-move'
+    node.is_async_command = True
+    node.saw_running = False
+    node.current_command_id = None
+    node.expected_kachaka_method = 'move_to_pose'
+    node.command_dispatched_at = time.monotonic()
+    node.command_target_pose = Pose(1.0, 1.0, 0.0)
+    node._get_command_state_response = MagicMock(
+        return_value={
+            'commandId': 'own-move-1',
+            'state': 'COMMAND_STATE_RUNNING',
+            'command': {
+                'moveToPoseCommand': {
+                    'x': 1.05,
+                    'y': 0.98,
+                    'yaw': 0.01
+                },
+            },
+        })
+
+    asyncio.run(node.publish_result())
+
+    assert node.current_command_id == 'own-move-1'
+    assert node.saw_running is True
+    assert published_payloads(node) == [{'id': 'cmd-own-move', 'is_completed': False}]
+
+
 # ---------------------------------------------------------------------------
 # Issue #34 Plan §7.2: command_dispatched_at origin (Codex review non-blocking finding)
 # ---------------------------------------------------------------------------
@@ -900,6 +969,60 @@ def test_own_return_home_retention_recorded_on_dock_completion() -> None:
     assert node._recently_own_return_home_until is not None
     assert node._recently_own_return_home_until > time.monotonic()
     assert node.task_id is None
+
+
+def test_own_return_home_retention_recorded_via_publish_result_completion_path() -> None:
+    """Own ID retention must also be recorded on the ordinary publish_result() success path.
+
+    Reproduces Codex re-review ISS34-010 recommendation-2: the retention
+    record was previously written only inside _publish_command_completion(),
+    but a normal async dock success completes through publish_result()'s own
+    publish-and-reset branch, which called _reset_async_command_state()
+    directly and skipped the record entirely. Without it, a briefly
+    lingering RUNNING return_home right after an ordinary dock success would
+    be misclassified as external control (Issue #34 Plan §7.4 concern (b)).
+    """
+    node = make_node()
+    node.task_id = 'cmd-dock-normal'
+    node.last_command = {'id': 'cmd-dock-normal', 'method': 'dock', 'args': {}}
+    node.is_async_command = True
+    node.saw_running = True
+    node.current_command_id = 'own-return-home-normal'
+    node.expected_kachaka_method = 'return_home'
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'own-return-home-normal',
+        'state': 'COMMAND_STATE_SUCCEEDED'
+    })
+    node._get_last_command_result_response = MagicMock(
+        return_value={
+            'commandId': 'own-return-home-normal',
+            'result': {
+                'success': True,
+                'errorCode': 0
+            },
+            'command': {
+                'returnHomeCommand': {}
+            },
+        })
+
+    asyncio.run(node.publish_result())
+
+    assert published_payloads(node) == [{'id': 'cmd-dock-normal', 'is_completed': True, 'success': True}]
+    assert node.task_id is None
+    assert node._recently_own_return_home_id == 'own-return-home-normal'
+    assert node._recently_own_return_home_until is not None
+    assert node._recently_own_return_home_until > time.monotonic()
+
+    # A lingering RUNNING return_home right after must still be recognized as ours.
+    node._get_command_state_response = MagicMock(return_value={
+        'commandId': 'own-return-home-normal',
+        'state': 'COMMAND_STATE_RUNNING',
+        'command': {
+            'returnHomeCommand': {}
+        },
+    })
+    asyncio.run(node.monitor_external_control())
+    assert node.external_control_active is False
 
 
 def test_external_control_active_rejects_new_rmf_command_with_external_busy() -> None:

--- a/test/test_map_state_guard.py
+++ b/test/test_map_state_guard.py
@@ -131,14 +131,24 @@ def test_guard_rejects_genuine_mismatch() -> None:
     assert node._verify_map_for_navigation('12F') is True  # sanity: robot is on 12F
     node = make_node(telemetry_map_name='12F', robot_map_name='L12')
     assert node._verify_map_for_navigation('8F') is False
-    assert published_completions(node) == [{'success': False, 'error_code': -2, 'task_id': None}]
+    assert published_completions(node) == [{
+        'success': False,
+        'error_code': -2,
+        'task_id': None,
+        'reason': 'map_mismatch',
+    }]
 
 
 def test_guard_rejects_when_robot_unreachable() -> None:
     """Navigation is rejected (not allowed through) when gRPC fails."""
     node = make_node(telemetry_map_name='12F', grpc_error=True)
     assert node._verify_map_for_navigation('8F') is False
-    assert published_completions(node) == [{'success': False, 'error_code': -2, 'task_id': None}]
+    assert published_completions(node) == [{
+        'success': False,
+        'error_code': -2,
+        'task_id': None,
+        'reason': 'map_mismatch',
+    }]
     # Cache must not be corrupted on failure
     assert node.map_state.telemetry_map_name == '12F'
 


### PR DESCRIPTION
## 概要

Kachaka ブリッジ (connect_openrmf_by_zenoh.py) のコマンドライフサイクルと状態送信を堅牢化する PR です。対象は Issue https://github.com/sbgisen-confidential/shintoda_rmf_demos/issues/34 （2026-07-17 エレベータ降車信号未送信事故）の Step 2（kachaka-api-for-openrmf 側対応）で、事故2系統（かご内の約12cm移動が約91秒 PENDING のまま止まりプランが停止した事象）の再発防止が目的です。正規仕様は別リポジトリ（sbgisen-confidential/shintoda_rmf_demos）の Issue #34 実装 Plan 文書（非公開）に基づきます。この PR 単体では Issue #34 はクローズしません。

## 何が変わるか

- RUNNING にならない、または RUNNING のまま位置が動かない状態を2段タイムアウトで検知し、詰まったら1回だけ失敗完了にします
- Kachaka から返ってきた成功が今出している RMF 指示と本当に同じものか（command 種別・現在階・目標位置）を確認してから成功を伝えます
- RMF が出していない Kachaka 側の操作（アプリの Return Home ボタン操作やロボット側の自動帰還など）を検知したら、進行中の RMF 指示を打ち切って外部操作中として扱い、その間の新しい RMF 指示は Kachaka に送りません。所有権判定は StartCommand 応答から同期取得した command ID との完全一致のみで行い、command 種別や目標位置による判定は使いません。これにより command 種別を問わず外部操作を検知できます（実機試験で「Return Home ボタンは returnHomeCommand ではなく moveToLocationCommand として観測される」ことが判明し、型で絞り込む方式から command ID 完全一致方式に作り直しました）
- ほぼ動かない距離（14.9cm 程度）の移動指示は Kachaka を呼ばずその場で成功にするショートカットを実装していますが、実機で「健全な状態でも微小移動が実行されない」ことが未確認のため既定では無効にしています
- 階名と位置をセットで1つの状態として送る新しい Zenoh key を追加します（既存の pose/map_name/battery は維持）

## 試し方

```bash
cd kachaka-api-for-openrmf
pytest -q test
vulture scripts/ test/ --min-confidence 60
ruff check --config ~/work/.github/pyproject.toml scripts/ test/
```

新規・既存テストが全て通ることを確認してください。実機結合試験は本 Plan の Step 4（別タスク）で実施予定です。

<details>
<summary>実装内容の詳細</summary>

### config/config.yaml

- `timeouts.command_start` (15.0s): 指示送信から RUNNING 確認までの上限
- `timeouts.motion_progress` (30.0s): RUNNING 後、位置/角度に有意な変化がない時間の上限
- `navigation.noop_distance_tolerance` (0.15m) / `noop_yaw_tolerance` (0.10rad): 近距離移動の即時完了判定
- `navigation.noop_enabled` (既定 `false`): 近距離移動の即時完了ショートカットの有効/無効。実機で健全時に微小移動が実行されないことを確認できた場合のみ `true` に変更してください
- `navigation.progress_distance_delta` (0.02m) / `progress_yaw_delta` (0.02rad): 「動いた」とみなす最小変化量
- `navigation.command_match_distance_tolerance` (0.75m) / `command_match_yaw_tolerance` (0.35rad): Kachaka 成功結果が実際に目標へ到達したかを確認する際の許容値。近距離判定用の tolerance とは別枠にしています。理由: Kachaka 自身の move_to_pose 成功は目標から 0.2〜0.3m 程度ずれることがあり、厳しい値だと正常な成功まで失敗扱いになってしまうためです（fleet_adapter_zenoh の localize_guard と同オーダーの値を採用）

### scripts/connect_openrmf_by_zenoh.py

- `_is_near_target()` / `_normalize_angle()`: 距離・角度（±πをまたぐ場合を正規化）の近接判定。近距離移動の即時完了と、成功結果の位置確認の両方で使用
- `_command_start_timeout_expired()` / `_motion_progress_timeout_expired()` / `_check_motion_progress()`: 2段タイムアウト。RUNNING 応答だけでは進捗とみなさず、実際の位置変化を進捗の根拠にしています
- `_validate_command_match()`: Kachaka の成功結果が持つ command 種別・現在階・目標位置を、こちらが出した指示の期待値と照合します。フロア不一致は `reason=map_mismatch`、種別不一致は理由なしの失敗として扱います
- `monitor_external_control()` / `_is_own_return_home()` / `_handle_external_return_home_started/_ended()`: 外部操作検出。command 種別で絞り込まず、こちらが出した指示の command ID と一致しない RUNNING command は種別を問わず外部操作として扱います（未知の種別は安全側に倒して busy 扱い）。最初の確定した観測で即座に `external_preempted` / `external_busy` へ遷移します。StartCommand 応答に command ID が含まれない異常系は bind せず fail-closed で即座に失敗完了とします（`reason=missing_command_id`）。bind 済みの指示に対しては、RUNNING を own progress として受理する際の GetCommandState commandId 完全一致と、完了判定に使う GetLastCommandResult commandId 完全一致をそれぞれ要求し、いずれも空・欠落の場合は成功として受理せず fail-closed に扱います（Kachaka API の公式 client wrapper も command ID の完全一致を要求するため、この方針と整合します）。completion の所有権判定は GetLastCommandResult 側の commandId 一致のみで行い、GetCommandState が非 RUNNING（実機で観測される完了直後の PENDING/commandId 欠落遷移を含む）であっても LastResult の取得・判定へ進みます。指示送信中（command ID 未確定の間）に外部 command らしき RUNNING を観測した場合は判定を1回保留し、送信確定後に改めて判定することで短命な外部 command も見逃しません。この保留・再判定は command ID を取得できる非同期指示（move_to_pose/return_home）のみに適用し、command ID を取得しない同期指示（switch_map 等）では行いません（同期指示自身の command を外部操作と誤検知しないため）。アイドル中に検知した busy 状態は、外部 command が完全に消えるまで解除しません
- `publish_state()`: 階名→位置→階名の順に取得し、前後の階名が一致した回のみ `robots/{robot_name}/state` へ送信します。switch_map と競合した回や gRPC エラー時は送信せず破棄します（gRPC エラー時に古い位置を新しい時刻で再送しないため）
- `CommandCompletion` に任意フィールド `reason` を追加しました（`start_timeout` / `progress_timeout` / `external_preempted` / `external_busy` / `map_mismatch` / `missing_command_id`）。既存 consumer は無視できる追加フィールドです。state payload のスキーマ（`schema_version: 1`）は変更していません
- 既存の pose/map_name/battery 用 publisher・publish 処理は変更していません

### 既知の注意点（fleet 側タスク ISS34-003 との共有事項）

- `state` payload の `seq` はブリッジ再起動でリセットされます。fleet 側の重複判定が seq 単調増加のみに依存する場合、再起動直後は新しい状態が一時的に無視される可能性があります。fleet 側は受信時刻ベースの鮮度判定も併用する設計になっているためこの影響は緩和されますが、実装時に考慮をお願いします

### 対象外・既知の残課題

- リフト乗車中の重大警告等、fleet 側（fleet_adapter_zenoh）に積む対応は本 PR の範囲外です

</details>


