### PR TITLE
fix: ログ衛生改善 (サードパーティDEBUG抑制 + ローテーション)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Run the following lines to launch the Zenoh node for Kachaka.
 cd ~/kachaka_ws
 export KACHAKA_ACCESS_POINT=$KACHAKA_IP:26400
 export ZENOH_ROUTER_ACCESS_POINT=<access_point_of_the_zenoh_router>  # e.g. 192.168.1.1:7447
+export LOG_LEVEL=INFO  # recommended default; use DEBUG only while investigating an issue, not for routine operation
 pipenv run python /path/to/kachaka-api-for-openrmf/scripts/connect_openrmf_by_zenoh.py
 ```
 

--- a/scripts/connect_openrmf_by_zenoh.py
+++ b/scripts/connect_openrmf_by_zenoh.py
@@ -20,6 +20,7 @@ import asyncio
 from dataclasses import dataclass
 import json
 import logging
+import logging.handlers
 import math
 import os
 from pathlib import Path
@@ -259,11 +260,19 @@ class KachakaApiClientByZenoh:
                                if kachaka_access_point else KachakaApiClientWithKeepalive())
         self.robot_name = robot_name
         self.task_id = None
-        logging.basicConfig(
-            level=self.log_level,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            filename='kachaka_api.log',
-        )
+        root_logger = logging.getLogger()
+        root_logger.setLevel(logging.WARNING)
+        if not root_logger.handlers:
+            file_handler = logging.handlers.RotatingFileHandler('kachaka_api.log',
+                                                                maxBytes=50 * 1024 * 1024,
+                                                                backupCount=3)
+            file_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+            root_logger.addHandler(file_handler)
+        # Third-party libraries are noisy at DEBUG (e.g. asyncio's
+        # "Using selector: EpollSelector"); pin them to WARNING so only this
+        # app's own logger follows LOG_LEVEL.
+        for noisy_logger_name in ('asyncio', 'urllib3', 'zenoh'):
+            logging.getLogger(noisy_logger_name).setLevel(logging.WARNING)
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(self.log_level)
 


### PR DESCRIPTION
## 背景

実機の ~/kachaka_api.log が 873MB まで肥大化していた。原因は次の2点。

1. LOG_LEVEL=DEBUG が root ロガーごと DEBUG にしていたため、asyncio (`Using selector: EpollSelector` 等)・urllib3・zenoh など、サードパーティのDEBUGログまで全部書き込まれていた。
2. ログファイルにローテーションが無く、追記一辺倒だった。

## 変更内容

- root ロガーを WARNING に固定し、asyncio / urllib3 / zenoh の named logger も明示的に WARNING に設定した。自アプリのロガー (`connect_openrmf_by_zenoh.py` の `self.logger`) だけが LOG_LEVEL 環境変数に従う。
- `~/kachaka_api.log` を書き出していた `logging.basicConfig(filename=...)` を `RotatingFileHandler` (50MB × 3世代) に置き換え、無制限肥大化を防止した。
- README にLOG_LEVEL の推奨値 (既定 INFO、DEBUG は検証時のみ) を追記した。

## 試し方

```bash
export LOG_LEVEL=DEBUG
python3 scripts/connect_openrmf_by_zenoh.py
```

起動後、`kachaka_api.log` に自アプリのDEBUGログは出るが、`Using selector: EpollSelector` 等のサードパーティDEBUGログは出ないことを確認できる。

## 動作確認

- `python3 -m pytest -q test` : 54 passed
- `ruff check` (scripts/connect_openrmf_by_zenoh.py, test/) : エラー0件 (rest_kachaka_api.py の既知19件は対象外・未変更)
- `pre-commit run --all-files` : Detect secrets (setup_local/Pipfile.lock) と ruff (rest_kachaka_api.py) の既知2件のfailを除き Passed

## 注記

このPRは PR #48 (`fix/issue34-command-and-state-safety`) の head を base にした stacked PR です。PR #48 が main にマージされたら、base は main に付け替わります。

<details>
<summary>詳細</summary>

`connect_openrmf_by_zenoh.py` のコンストラクタで行っていた `logging.basicConfig(level=self.log_level, filename='kachaka_api.log')` は、root ロガーとその配下すべて (サードパーティ含む) に同じレベルとファイル出力を適用してしまう作りだった。これを次の形に変更した。

```python
root_logger = logging.getLogger()
root_logger.setLevel(logging.WARNING)
if not root_logger.handlers:
    file_handler = logging.handlers.RotatingFileHandler(
        'kachaka_api.log', maxBytes=50 * 1024 * 1024, backupCount=3)
    file_handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
    root_logger.addHandler(file_handler)
for noisy_logger_name in ('asyncio', 'urllib3', 'zenoh'):
    logging.getLogger(noisy_logger_name).setLevel(logging.WARNING)
self.logger = logging.getLogger(__name__)
self.logger.setLevel(self.log_level)
```

`rest_kachaka_api.py` (uvicornで起動する別プロセス) は元々ロギング設定を持っておらず、`~/kachaka_api.log` の書き込み元ではないため変更していない。`kachaka_client_with_keepalive.py` および `kachaka_api` パッケージ本体もロギング呼び出しを持たないため、退行の心配はない。

</details>